### PR TITLE
limit lookup scope for damage calculations

### DIFF
--- a/src/module/actors/sheets/character-sheet.js
+++ b/src/module/actors/sheets/character-sheet.js
@@ -470,12 +470,13 @@ export class STACharacterSheet extends ActorSheet {
         parseInt(selectedAttributeValue), selectedDiscipline,
         parseInt(selectedDisciplineValue), null, this.actor);
     });
-    
-    $.each($('[id^=character-weapon-]'), function(index, value) {
+
+    $(html).find('[id^=character-weapon-]').each(function(_, value){
       let weaponDamage = parseInt(value.dataset.itemDamage);
       let securityValue = parseInt(html.find('#security')[0].value);
       let attackDamageValue = weaponDamage + securityValue;
       value.getElementsByClassName('damage')[0].innerText = attackDamageValue;
     });
+
   }
 }

--- a/src/module/actors/sheets/smallcraft-sheet.js
+++ b/src/module/actors/sheets/smallcraft-sheet.js
@@ -388,7 +388,7 @@ export class STASmallCraftSheet extends ActorSheet {
         parseInt(selectedDepartmentValue), null, this.actor);
     });
     
-    $.each($('[id^=smallcraft-weapon-]'), function(index, value) {
+    $(html).find('[id^=smallcraft-weapon-]').each(function(_, value){
       let weaponDamage = parseInt(value.dataset.itemDamage);
       let securityValue = parseInt(html.find('#security')[0].value);
       let attackDamageValue = weaponDamage + securityValue;

--- a/src/module/actors/sheets/starship-sheet.js
+++ b/src/module/actors/sheets/starship-sheet.js
@@ -451,7 +451,7 @@ export class STAStarshipSheet extends ActorSheet {
         parseInt(selectedDepartmentValue), null, this.actor);
     });
     
-    $.each($('[id^=starship-weapon-]'), function(index, value) {
+    $(html).find('[id^=starship-weapon-]').each(function(_, value){
       let weaponDamage = parseInt(value.dataset.itemDamage);
       let securityValue = parseInt(html.find('#security')[0].value);
       let attackDamageValue = weaponDamage + securityValue;


### PR DESCRIPTION
The original lookup scope of the weapon damage calculations was essentially the whole page. This changes limits the scope to only be the form of the application/sheet for which the script is run. Therefore, calculated weapon damages are no longer overwritten.

Fixes #56 