### PR TITLE
Replace sidebar LCARS deco with hard gradient

### DIFF
--- a/src/module/sta.js
+++ b/src/module/sta.js
@@ -233,22 +233,9 @@ Hooks.once('init', function() {
     renderTemplate('systems/sta/templates/apps/tracker.html').then((html) => {
       t.render(true);
     });
-
-    const sidebar = $("#sidebar");
-    sidebar.find("nav#sidebar-tabs .collapse").on("click", () => {
-      if (!sidebar.hasClass("collapse")) {
-        sidebar.addClass("nolcars");
-      }
-    });
   });
 
   Hooks.once("diceSoNiceReady", (dice3d) => {
     register_dsn_ufp_themes(dice3d);
-  });
-
-  Hooks.on("collapseSidebar", (_, collapsed) => {
-    if(!collapsed) {
-      $("#sidebar").removeClass("nolcars");
-    }
   });
 });

--- a/src/module/sta.js
+++ b/src/module/sta.js
@@ -233,9 +233,22 @@ Hooks.once('init', function() {
     renderTemplate('systems/sta/templates/apps/tracker.html').then((html) => {
       t.render(true);
     });
+
+    const sidebar = $("#sidebar");
+    sidebar.find("nav#sidebar-tabs .collapse").on("click", () => {
+      if (!sidebar.hasClass("collapse")) {
+        sidebar.addClass("nolcars");
+      }
+    });
   });
 
   Hooks.once("diceSoNiceReady", (dice3d) => {
     register_dsn_ufp_themes(dice3d);
+  });
+
+  Hooks.on("collapseSidebar", (_, collapsed) => {
+    if(!collapsed) {
+      $("#sidebar").removeClass("nolcars");
+    }
   });
 });

--- a/src/styles/sta.scss
+++ b/src/styles/sta.scss
@@ -1205,8 +1205,29 @@ $trackColors: (
 /* Sidebar */ /*#region*/
 
 #sidebar {
+  &:not(.nolcars) {
+    background: linear-gradient(to bottom,
+      map-get($lcarsColors, "tan"),
+      map-get($lcarsColors, "tan") 14%,
+      $background 14%,
+      $background calc(14% + 5px),
+      map-get($lcarsColors, "lightblue") calc(14% + 5px),
+      map-get($lcarsColors, "lightblue") 39%,
+      $background 39%,
+      $background calc(39% + 5px),
+      map-get($lcarsColors, "tan") calc(39% + 5px),
+      map-get($lcarsColors, "tan") 59%,
+      $background calc(59%),
+      $background calc(59% + 5px),
+      map-get($lcarsColors, "orange") calc(59% + 5px),
+      map-get($lcarsColors, "orange") 80%,
+      $background calc(80%),
+      $background calc(80% + 5px),
+      map-get($lcarsColors, "tan") calc(80% + 5px),
+    );
+  }
+
   &:not(.collapsed) {
-    background: none;
     border:none;
     background-color: map-get($lcarsColors, "tan");
     width: 350px;
@@ -1302,30 +1323,6 @@ $trackColors: (
 
       }
     }
-  }
-
-  &::before {
-    content: "";
-    position: absolute;
-    bottom: 60%;
-    right: 305px;
-    height: 25%;
-    width: 50px;
-    background-color: map-get($lcarsColors, "lightblue"); 
-    border-top: 5px solid $background;
-    border-bottom: 5px solid $background;
-  }
-
-  &::after {
-    content: "";
-    position: absolute;
-    bottom: 20%;
-    right: 305px;
-    height: 20%;
-    width: 50px;
-    background-color: map-get($lcarsColors, "orange"); 
-    border-top: 5px solid $background;
-    border-bottom: 5px solid $background;
   }
 }
 /*#endregion*/

--- a/src/styles/sta.scss
+++ b/src/styles/sta.scss
@@ -1205,8 +1205,13 @@ $trackColors: (
 /* Sidebar */ /*#region*/
 
 #sidebar {
-  &:not(.nolcars) {
-    background: linear-gradient(to bottom,
+  &:not(.collapsed) {
+    background: linear-gradient(to right,
+    rgba(0, 0, 0, 0),
+    rgba(0, 0, 0, 0) 50px,
+    $background 50px,
+    $background),
+    linear-gradient(to bottom,
       map-get($lcarsColors, "tan"),
       map-get($lcarsColors, "tan") 14%,
       $background 14%,
@@ -1223,13 +1228,9 @@ $trackColors: (
       map-get($lcarsColors, "orange") 80%,
       $background calc(80%),
       $background calc(80% + 5px),
-      map-get($lcarsColors, "tan") calc(80% + 5px),
+      map-get($lcarsColors, "tan") calc(80% + 5px)
     );
-  }
-
-  &:not(.collapsed) {
     border:none;
-    background-color: map-get($lcarsColors, "tan");
     width: 350px;
     border-top-left-radius: 35px;
     border-bottom-left-radius: 0;


### PR DESCRIPTION
This replaces the `::before`/`::after` LCARS styling of the sidebar with a stepped/hard gradient. Collapsing is not entirely perfect but it essentially fixes the sidebar aspect of #57.