### PR TITLE
Correct the return type from STAExtendedTaskSheet.getData()

### DIFF
--- a/src/module/actors/sheets/extended-task-sheet.js
+++ b/src/module/actors/sheets/extended-task-sheet.js
@@ -35,7 +35,7 @@ export class STAExtendedTaskSheet extends ActorSheet {
     if (sheetData.system.difficulty < 0) sheetData.system.difficulty = 0;
     if (sheetData.system.resistance < 0) sheetData.system.resistance = 0;
     
-    return sheetData.system;
+    return sheetData;
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
This fixes #84 - Extended tasks not worling.

Just a little one-liner fix. Tested with a local foundry instance, also compare the return type of other actors.