### PR TITLE
Fixed: Foundry v11 sheet crash from default item image stopgap

### DIFF
--- a/src/module/actors/sheets/character-sheet.js
+++ b/src/module/actors/sheets/character-sheet.js
@@ -258,7 +258,7 @@ export class STACharacterSheet extends ActorSheet {
       }
     });
 
-    // Allows item-delete images to allow deletion of the selected item. This uses Simple Worldbuilding System Code.
+    // Allows item-delete images to allow deletion of the selected item.
     html.find('.control .delete').click((ev) => {
       const li = $(ev.currentTarget).parents('.entry');
       const r = confirm('Are you sure you want to delete ' + li[0].getAttribute('data-item-value') + '?');

--- a/src/module/actors/sheets/character-sheet.js
+++ b/src/module/actors/sheets/character-sheet.js
@@ -258,7 +258,7 @@ export class STACharacterSheet extends ActorSheet {
       }
     });
 
-    // Allows item-delete images to allow deletion of the selected item.
+    // Allows item-delete images to allow deletion of the selected item. This uses Simple Worldbuilding System Code.
     html.find('.control .delete').click((ev) => {
       const li = $(ev.currentTarget).parents('.entry');
       const r = confirm('Are you sure you want to delete ' + li[0].getAttribute('data-item-value') + '?');

--- a/src/module/actors/sheets/character-sheet.js
+++ b/src/module/actors/sheets/character-sheet.js
@@ -75,13 +75,7 @@ export class STACharacterSheet extends ActorSheet {
     if (sheetData.system.reputation < 0) {
       sheetData.system.reputation = 0;
     }
-
-    // Checks if items for this actor have default images. Something with Foundry 0.7.9 broke this functionality operating normally.
-    // Stopgap until a better solution can be found.
-    $.each(sheetData.items, (key, item) => {
-      if (!item.img) item.img = game.sta.defaultImage;
-    })
-
+    
     return sheetData;
   }
 

--- a/src/module/actors/sheets/smallcraft-sheet.js
+++ b/src/module/actors/sheets/smallcraft-sheet.js
@@ -64,12 +64,6 @@ export class STASmallCraftSheet extends ActorSheet {
       sheetData.system.power.value = 0;
     }
 
-    // Checks if items for this actor have default images. Something with Foundry 0.7.9 broke this functionality operating normally.
-    // Stopgap until a better solution can be found.
-    $.each(sheetData.items, (key, item) => {
-      if (!item.img) item.img = game.sta.defaultImage;
-    })
-
     return sheetData;
   }
 

--- a/src/module/actors/sheets/starship-sheet.js
+++ b/src/module/actors/sheets/starship-sheet.js
@@ -69,12 +69,6 @@ export class STAStarshipSheet extends ActorSheet {
       sheetData.system.crew.value = 0;
     }
 
-    // Checks if items for this actor have default images. Something with Foundry 0.7.9 broke this functionality operating normally.
-    // Stopgap until a better solution can be found.
-    $.each(sheetData.items, (key, item) => {
-      if (!item.img) item.img = game.sta.defaultImage;
-    })
-
     return sheetData;
   }
 


### PR DESCRIPTION
Fixes #92 by simply removing the offending code block.  This appears to be code that is no longer necessary, as default item images seem to be working fine to me.  Foundry must have fixed the bug introduced in 2021 at some point!

If this does turn out to be necessary, the following update could be applied, instead.  I don't know what the kind of object `sheetData.items` used to be (I'm assuming a regular Object), but the jQuery was tripped up by the switch to EmbeddedCollection.

```
sheetData.items.forEach((item) => {
  if (!item.img) item.img = game.sta.defaultImage;
});
```

