### PR TITLE
Delete confirm dialog switched to Foundry UI Dialog instead of confirm() call.

### DIFF
--- a/src/module/actors/actor.js
+++ b/src/module/actors/actor.js
@@ -163,4 +163,35 @@ export class STASharedActorFunctions {
       break;
     }
   }
+
+  /**
+   * Create the "Are you sure?" delete dialog used for sheets' item delete behavior.
+   *
+   * @param {string} itemName - The item name to display.
+   * @param {function} yesCb - The callback to handle a "yes" click.
+   * @param {function} closeCb - The callback handling a "close" event.
+   *
+   * @return {Dialog}
+   */
+  deleteConfirmDialog(itemName, yesCb, closeCb) {
+
+    // Dialog uses Simple Worldbuilding System Code.
+    return new Dialog({
+      title: 'Confirm Item Deletion',
+      content: 'Are you sure you want to delete ' + itemName + '?',
+      buttons: {
+        yes: {
+          icon: '<i class="fas fa-check"></i>',
+          label: game.i18n.localize("Yes"),
+          callback: yesCb,
+        },
+        no: {
+          icon: '<i class="fas fa-times"></i>',
+          label: game.i18n.localize("No"),
+        }
+      },
+      default: 'no',
+      close: closeCb,
+    });
+  }
 }

--- a/src/module/actors/sheets/character-sheet.js
+++ b/src/module/actors/sheets/character-sheet.js
@@ -264,7 +264,7 @@ export class STACharacterSheet extends ActorSheet {
       }
     });
 
-    // Allows item-delete images to allow deletion of the selected item. This uses Simple Worldbuilding System Code.
+    // Allows item-delete images to allow deletion of the selected item.
     html.find('.control .delete').click((ev) => {
       const li = $(ev.currentTarget).parents('.entry');
       this.activeDialog = staActor.deleteConfirmDialog(

--- a/src/module/actors/sheets/character-sheet.js
+++ b/src/module/actors/sheets/character-sheet.js
@@ -267,15 +267,18 @@ export class STACharacterSheet extends ActorSheet {
     // Allows item-delete images to allow deletion of the selected item. This uses Simple Worldbuilding System Code.
     html.find('.control .delete').click((ev) => {
       const li = $(ev.currentTarget).parents('.entry');
-      const r = confirm('Are you sure you want to delete ' + li[0].getAttribute('data-item-value') + '?');
-      if (r == true) {
-        if (isNewerVersion(versionInfo, '0.8.-1')) {
-          this.actor.deleteEmbeddedDocuments('Item', [li.data('itemId')]);
-        } else {
-          this.actor.deleteOwnedItem(li.data('itemId'));
-        }
-        li.slideUp(200, () => this.render(false));
-      }
+      this.activeDialog = staActor.deleteConfirmDialog(
+        li[0].getAttribute('data-item-value'),
+        () => {
+          if ( isNewerVersion( versionInfo, '0.8.-1' )) {
+            this.actor.deleteEmbeddedDocuments( 'Item', [li.data('itemId')] );
+          } else {
+            this.actor.deleteOwnedItem( li.data( 'itemId' ));
+          }
+        },
+        () => this.activeDialog = null
+      );
+      this.activeDialog.render(true);
     });
 
     // Reads if a reputation track box has been clicked, and if it has will either: set the value to the clicked box, or reduce the value by one. 

--- a/src/module/actors/sheets/smallcraft-sheet.js
+++ b/src/module/actors/sheets/smallcraft-sheet.js
@@ -207,18 +207,24 @@ export class STASmallCraftSheet extends ActorSheet {
       }
     });
 
-    // Allows item-delete images to allow deletion of the selected item. This uses Simple Worldbuilding System Code.
+    // Allows item-delete images to allow deletion of the selected item.
     html.find('.control .delete').click( (ev) => {
+      // Cleaning up previous dialogs is nice, and also possibly avoids bugs from invalid popups.
+      if (this.activeDialog) this.activeDialog.close();
+
       const li = $(ev.currentTarget).parents('.entry');
-      const r = confirm('Are you sure you want to delete ' + li[0].getAttribute('data-item-value') + '?');
-      if (r == true) {
-        if ( isNewerVersion( versionInfo, '0.8.-1' )) {
-          this.actor.deleteEmbeddedDocuments('Item', [li.data('itemId')] ); 
-        } else {
-          this.actor.deleteOwnedItem( li.data( 'itemId' )); 
-        }
-        li.slideUp(200, () => this.render(false));
-      }
+      this.activeDialog = staActor.deleteConfirmDialog(
+        li[0].getAttribute('data-item-value'),
+        () => {
+          if ( isNewerVersion( versionInfo, '0.8.-1' )) {
+            this.actor.deleteEmbeddedDocuments( 'Item', [li.data('itemId')] );
+          } else {
+            this.actor.deleteOwnedItem( li.data( 'itemId' ));
+          }
+        },
+        () => this.activeDialog = null
+      );
+      this.activeDialog.render(true);
     });
 
     // Reads if a shields track box has been clicked, and if it has will either: set the value to the clicked box, or reduce the value by one.

--- a/src/module/actors/sheets/starship-sheet.js
+++ b/src/module/actors/sheets/starship-sheet.js
@@ -3,6 +3,13 @@ import {
 } from '../actor.js';
 
 export class STAStarshipSheet extends ActorSheet {
+
+  /**
+   * An actively open dialog that should be closed before a new one is opened.
+   * @type {Dialog}
+   */
+  activeDialog;
+
   /** @override */
   static get defaultOptions() {
     return mergeObject(super.defaultOptions, {
@@ -237,17 +244,24 @@ export class STAStarshipSheet extends ActorSheet {
       }
     });
 
-    // Allows item-delete images to allow deletion of the selected item. This uses Simple Worldbuilding System Code.
+    // Allows item-delete images to allow deletion of the selected item.
     html.find('.control .delete').click((ev) => {
+      // Cleaning up previous dialogs is nice, and also possibly avoids bugs from invalid popups.
+      if (this.activeDialog) this.activeDialog.close();
+
       const li = $(ev.currentTarget).parents('.entry');
-      const r = confirm('Are you sure you want to delete ' + li[0].getAttribute('data-item-value') + '?');
-      if ( r == true ) {
-        if ( isNewerVersion( versionInfo, '0.8.-1' )) {
-          this.actor.deleteEmbeddedDocuments( 'Item', [li.data('itemId')] ); 
-        } else {
-          this.actor.deleteOwnedItem( li.data( 'itemId' )); 
-        }
-      }
+      this.activeDialog = staActor.deleteConfirmDialog(
+        li[0].getAttribute('data-item-value'),
+        () => {
+          if ( isNewerVersion( versionInfo, '0.8.-1' )) {
+            this.actor.deleteEmbeddedDocuments( 'Item', [li.data('itemId')] );
+          } else {
+            this.actor.deleteOwnedItem( li.data( 'itemId' ));
+          }
+        },
+        () => this.activeDialog = null
+      );
+      this.activeDialog.render(true);
     });
 
     // Reads if a shields track box has been clicked, and if it has will either: set the value to the clicked box, or reduce the value by one.


### PR DESCRIPTION
This was primarily done to address a known cause of #60, which was the call to confirm() when a user attempts to delete an item from a character sheet.  The secondary benefit is that we get a dialog that more visually integrates into Foundry's UI.

I moved the Dialog creation code into actor.js for lack of a better home for a shared utility function.  I noticed one was there for handling other character sheet behavior.  I kept the comment about `Simple Worldbuilding System Code` because that's where I ultimately looked for inspiration, myself.

I removed the `li.slideUp(200, () => this.render(false));` line because, as far as I can tell, it wasn't working.  Perhaps in older supported versions it did, but in V11 the sheet immediately removes the item and doesn't give it a chance to animate.

Minimal work was done about formatting, this is perhaps something worth spending time on in the future.

I also took the extra step to clean up older Dialogs before creating new ones.  Even though Foundry doesn't seem to even do this (you can create a million sheet configuration popups), I went this direction because it keeps things tidy and also prevents potential headaches caused by remnant confirm dialogs sitting around and getting clicked long after the related items were removed.



