### PR TITLE
Minor dev tooling improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,20 @@ You <b> MUST </b> own the <a href="https://www.modiphius.net/collections/star-tr
 ---
 
 ## Development Environment
-In order to build successfully, you will need to update `foundryconfig.json` and direct it to the appropriate [Foundry VTT Data directory](https://foundryvtt.com/article/configuration). 
+If you are using a non-standard [Foundry VTT Data directory](https://foundryvtt.com/article/configuration), you will need to update `foundryconfig.json` with your data directory. Otherwise, the build will assume the default location for your platform.
+
+### Common Build Commands
+
+```
+# Build STA and copy it to Foundry
+$ npm run build
+
+# Deletes the local build *AND* the copy in the Foundry data directory
+$ npm run clean
+
+# Run linters
+$ npm run lint
+```
 
 ## Thanks
 - Atropos, for creating Foundry Virtual Tabletop. It is an amazing VTT, especially if you want something highly customizable. <a href="https://foundryvtt.com/" target="_blank">https://foundryvtt.com/</a>.

--- a/foundryconfig.json
+++ b/foundryconfig.json
@@ -1,5 +1,5 @@
 {
-  "dataPath": "C:/Users/roric/AppData/Local/FoundryVTT",
+  "dataPath": "",
   "repository": "https://github.com/mkscho63/sta",
   "rawURL": "https://raw.githubusercontent.com/mkscho63/sta"
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -147,13 +147,26 @@ async function clean() {
   }
 }
 
+function defaultDataPath() {
+    switch (process.platform) {
+        case 'win32':
+            return path.resolve(process.env.localappdata, 'FoundryVTT')
+        case 'linux':
+            return path.resolve(process.env.HOME, '.local', 'share', 'FoundryVTT')
+        case 'darwin':
+            return path.resolve(process.env.HOME, 'Library', 'Application Support', 'FoundryVTT')
+        default:
+            throw Error("No known default for platform ${process.platform}")
+    }
+}
+
 // Copy files to test location
 async function copyUserData() {
   const name = path.basename(path.resolve('.'));
   const config = fs.readJSONSync('foundryconfig.json');
 
   let destDir;
-  
+
   try {
     if (fs.existsSync(path.resolve('.', 'dist', 'system.json')) ||
 			fs.existsSync(path.resolve('.', 'src', 'system.json'))) {
@@ -165,14 +178,17 @@ async function copyUserData() {
     }
 
     let linkDir;
+
+    if (!config.dataPath) {
+        config.dataPath = defaultDataPath()
+    }
+
     if (config.dataPath) {
       if (!fs.existsSync(path.join(config.dataPath, 'Data'))) {
         throw Error('User Data path invalid, no Data directory found');
       }
 
       linkDir = path.join(config.dataPath, 'Data', destDir, name);
-    } else {
-      throw Error('No User Data path defined in foundryconfig.json');
     }
 
     if (argv.clean || argv.c) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -148,16 +148,16 @@ async function clean() {
 }
 
 function defaultDataPath() {
-    switch (process.platform) {
-        case 'win32':
-            return path.resolve(process.env.localappdata, 'FoundryVTT')
-        case 'linux':
-            return path.resolve(process.env.HOME, '.local', 'share', 'FoundryVTT')
-        case 'darwin':
-            return path.resolve(process.env.HOME, 'Library', 'Application Support', 'FoundryVTT')
-        default:
-            throw Error("No known default for platform ${process.platform}")
-    }
+  switch (process.platform) {
+    case 'win32':
+      return path.resolve(process.env.localappdata, 'FoundryVTT')
+    case 'linux':
+      return path.resolve(process.env.HOME, '.local', 'share', 'FoundryVTT')
+    case 'darwin':
+      return path.resolve(process.env.HOME, 'Library', 'Application Support', 'FoundryVTT')
+    default:
+      throw Error("No known default for platform ${process.platform}")
+  }
 }
 
 // Copy files to test location


### PR DESCRIPTION
Hi folks, I've just been fiddling around a little (hope to contribute more substantial things in the future) but here's some little improvements to the build tooling that I found helpful when I was getting up and running today:

- uses platform defaults for data path (can still be overridden in foundryconfig.json)
- updates README with some basic commands for getting started

I'm running/developing on Linux, hence the additional platform defaults alongside Windows.