### PR TITLE
Code style and Lint Issue Correction, Automated Github ESLint Checking

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,7 +8,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install modules
         run: npm install
       - name: Run ESLint

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,15 @@
+name: Checks
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install modules
+        run: npm install
+      - name: Run ESLint
+        run: npx eslint .

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -83,7 +83,7 @@ export default [
       'linebreak-style': ['error', 'windows'],
       'indent': ['error', 2],
       'import/extensions': 'off',
-      'max-len': ['error', {'ignoreComments': true, 'ignoreStrings': true, 'ignoreTemplateLiterals': true}],
+      'max-len': ['error', {'code': 110, 'ignoreComments': true, 'ignoreStrings': true, 'ignoreTemplateLiterals': true}],
       'no-async-promise-executor': 'off',
       'no-await-in-loop': 'off',
       'no-console': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,7 +22,7 @@ google.plugins = {
  */
 delete google.rules['require-jsdoc'];
 google.rules['jsdoc/require-jsdoc'] = ['error', {
-  'require':{
+  'require': {
     FunctionDeclaration: true,
     MethodDefinition: true,
     ClassDeclaration: true,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,6 +44,10 @@ google.settings = {
 };
 
 export default [
+  // Temporarily ignoring tracker.js.  See tracker.js for details.
+  {
+    ignores: ['src/module/apps/tracker.js'],
+  },
   google,
   {
     languageOptions: {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -149,14 +149,14 @@ async function clean() {
 
 function defaultDataPath() {
   switch (process.platform) {
-    case 'win32':
-      return path.resolve(process.env.localappdata, 'FoundryVTT')
-    case 'linux':
-      return path.resolve(process.env.HOME, '.local', 'share', 'FoundryVTT')
-    case 'darwin':
-      return path.resolve(process.env.HOME, 'Library', 'Application Support', 'FoundryVTT')
-    default:
-      throw Error("No known default for platform ${process.platform}")
+  case 'win32':
+    return path.resolve(process.env.localappdata, 'FoundryVTT')
+  case 'linux':
+    return path.resolve(process.env.HOME, '.local', 'share', 'FoundryVTT')
+  case 'darwin':
+    return path.resolve(process.env.HOME, 'Library', 'Application Support', 'FoundryVTT')
+  default:
+    throw Error("No known default for platform ${process.platform}")
   }
 }
 
@@ -180,7 +180,7 @@ async function copyUserData() {
     let linkDir;
 
     if (!config.dataPath) {
-        config.dataPath = defaultDataPath()
+      config.dataPath = defaultDataPath();
     }
 
     if (config.dataPath) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -150,13 +150,13 @@ async function clean() {
 function defaultDataPath() {
   switch (process.platform) {
   case 'win32':
-    return path.resolve(process.env.localappdata, 'FoundryVTT')
+    return path.resolve(process.env.localappdata, 'FoundryVTT');
   case 'linux':
-    return path.resolve(process.env.HOME, '.local', 'share', 'FoundryVTT')
+    return path.resolve(process.env.HOME, '.local', 'share', 'FoundryVTT');
   case 'darwin':
-    return path.resolve(process.env.HOME, 'Library', 'Application Support', 'FoundryVTT')
+    return path.resolve(process.env.HOME, 'Library', 'Application Support', 'FoundryVTT');
   default:
-    throw Error('No known default for platform ${process.platform}')
+    throw Error('No known default for platform ${process.platform}');
   }
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -156,7 +156,7 @@ function defaultDataPath() {
   case 'darwin':
     return path.resolve(process.env.HOME, 'Library', 'Application Support', 'FoundryVTT')
   default:
-    throw Error("No known default for platform ${process.platform}")
+    throw Error('No known default for platform ${process.platform}')
   }
 }
 

--- a/src/module/actors/actor.js
+++ b/src/module/actors/actor.js
@@ -181,7 +181,6 @@ export class STASharedActorFunctions {
    * @return {Dialog}
    */
   deleteConfirmDialog(itemName, yesCb, closeCb) {
-
     // Dialog uses Simple Worldbuilding System Code.
     return new Dialog({
       title: 'Confirm Item Deletion',
@@ -189,12 +188,12 @@ export class STASharedActorFunctions {
       buttons: {
         yes: {
           icon: '<i class="fas fa-check"></i>',
-          label: game.i18n.localize("Yes"),
+          label: game.i18n.localize('Yes'),
           callback: yesCb,
         },
         no: {
           icon: '<i class="fas fa-times"></i>',
-          label: game.i18n.localize("No"),
+          label: game.i18n.localize('No'),
         }
       },
       default: 'no',
@@ -207,12 +206,11 @@ Hooks.on('createActor', async (actor, options, userId) => {
   if (game.user.id !== userId) return;
 
   if (actor.type === 'character') {
-
     const compendium2e = await game.packs.get('sta.equipment-crew');
-	const item1 = await compendium2e.getDocument('cxIi0Ltb1sUCFnzp');
+    const item1 = await compendium2e.getDocument('cxIi0Ltb1sUCFnzp');
 
     const compendium1e = await game.packs.get('sta.personal-weapons-core');
-	const item2 = await compendium1e.getDocument('3PTFLawY0tCva3gG');
+    const item2 = await compendium1e.getDocument('3PTFLawY0tCva3gG');
 
     if (item1 && item2) {
       await actor.createEmbeddedDocuments('Item', [
@@ -220,7 +218,7 @@ Hooks.on('createActor', async (actor, options, userId) => {
         item2.toObject()
       ]);
     } else {
-      console.error("One or both items were not found in the compendiums.");
+      console.error('One or both items were not found in the compendiums.');
     }
   }
 });

--- a/src/module/actors/sheets/character-sheet.js
+++ b/src/module/actors/sheets/character-sheet.js
@@ -68,8 +68,9 @@ export class STACharacterSheet extends ActorSheet {
     });
 
     // Check stress max/min
-    if (!(sheetData.system.stress))
+    if (!(sheetData.system.stress)) {
       sheetData.system.stress = {};
+    }
     if (sheetData.system.stress.value > sheetData.system.stress.max) {
       sheetData.system.stress.value = sheetData.system.stress.max;
     }
@@ -78,8 +79,9 @@ export class STACharacterSheet extends ActorSheet {
     }
 
     // Check determination max/min
-    if (!(sheetData.system.determination))
+    if (!(sheetData.system.determination)) {
       sheetData.system.determination = {};
+    }
     if (sheetData.system.determination.value > 3) {
       sheetData.system.determination.value = 3;
     }
@@ -88,8 +90,9 @@ export class STACharacterSheet extends ActorSheet {
     }
     
     // Check reputation max/min
-    if (!(sheetData.system.reputation))
+    if (!(sheetData.system.reputation)) {
       sheetData.system.reputation = {};
+    }
     if (sheetData.system.reputation.value > 20) {
       sheetData.system.reputation.value = 20;
     }
@@ -156,7 +159,7 @@ export class STACharacterSheet extends ActorSheet {
       if (html.find(`[data-talent-name*="${localizedValues.resolute}"]`).length > 0) {
         stressTrackMax += 3;
       }
-	  stressTrackMax += parseInt(html.find('#strmod')[0].value)
+	  stressTrackMax += parseInt(html.find('#strmod')[0].value);
       // This checks that the max-stress hidden field is equal to the calculated Max Stress value, if not it makes it so.
       if (html.find('#max-stress')[0].value != stressTrackMax) {
         html.find('#max-stress')[0].value = stressTrackMax;

--- a/src/module/actors/sheets/character-sheet.js
+++ b/src/module/actors/sheets/character-sheet.js
@@ -41,7 +41,9 @@ export class STACharacterSheet extends ActorSheet {
 	
     // Temporary fix I'm leaving in place until I deprecate in a future version
     const overrideMinAttributeTags = ['[Minor]', '[Notable]', '[Major]', '[NPC]', '[Child]'];
-    const overrideMinAttribute = overrideMinAttributeTags.some((tag) => sheetData.name.toLowerCase().indexOf(tag.toLowerCase()) !== -1);
+    const overrideMinAttribute = overrideMinAttributeTags.some(
+      (tag) => sheetData.name.toLowerCase().indexOf(tag.toLowerCase()) !== -1
+    );
     
 
     // Ensure attribute and discipline values aren't over the max/min.

--- a/src/module/actors/sheets/character-sheet.js
+++ b/src/module/actors/sheets/character-sheet.js
@@ -484,10 +484,9 @@ export class STACharacterSheet extends ActorSheet {
       this.submit();
     });
 
-  // If the check-button is clicked it performs the acclaim or reprimand calculation.
-  html.find('.check-button.acclaim').click(async (ev) => {
-
-  let dialogContent = `
+    // If the check-button is clicked it performs the acclaim or reprimand calculation.
+    html.find('.check-button.acclaim').click(async (ev) => {
+      const dialogContent = `
   <form class="sta-form">
       <div class="dice-pool flexcol">
           <div class="flexrow">
@@ -502,73 +501,73 @@ export class STACharacterSheet extends ActorSheet {
   </form>
   `;
 
-  new Dialog({
-    title: `${game.i18n.localize('sta.roll.acclaim')}`,
-    content: dialogContent,
-    buttons: {
-      roll: {
-        label: `${game.i18n.localize('sta.roll.acclaim')}`,
-        callback: async (html) => {
-          let PositiveInfluences = parseInt(html.find('#positiveInfluences').val()) || 1;
-          let NegativeInfluences = parseInt(html.find('#negativeInfluences').val()) || 0;
+      new Dialog({
+        title: `${game.i18n.localize('sta.roll.acclaim')}`,
+        content: dialogContent,
+        buttons: {
+          roll: {
+            label: `${game.i18n.localize('sta.roll.acclaim')}`,
+            callback: async (html) => {
+              const PositiveInfluences = parseInt(html.find('#positiveInfluences').val()) || 1;
+              const NegativeInfluences = parseInt(html.find('#negativeInfluences').val()) || 0;
           
-          let selectedDisciplineValue = parseInt(document.querySelector('#total-rep')?.value) || 0;
-          let existingReprimand = parseInt(document.querySelector('#reprimand')?.value) || 0;
-          let targetNumber = selectedDisciplineValue + 7;
-          let complicationThreshold = 20 - Math.min(existingReprimand, 5);
-          let diceRollFormula = `${PositiveInfluences}d20`;
-          let roll = new Roll(diceRollFormula);
+              const selectedDisciplineValue = parseInt(document.querySelector('#total-rep')?.value) || 0;
+              const existingReprimand = parseInt(document.querySelector('#reprimand')?.value) || 0;
+              const targetNumber = selectedDisciplineValue + 7;
+              const complicationThreshold = 20 - Math.min(existingReprimand, 5);
+              const diceRollFormula = `${PositiveInfluences}d20`;
+              const roll = new Roll(diceRollFormula);
 
-          await roll.evaluate();
+              await roll.evaluate();
 
-          let totalSuccesses = 0;
-          let complications = 0;
-          let acclaim = 0;
-          let reprimand = 0;
-          let diceResults = [];
+              let totalSuccesses = 0;
+              let complications = 0;
+              let acclaim = 0;
+              let reprimand = 0;
+              const diceResults = [];
 
-          roll.terms[0].results.forEach(die => {
-            let coloredDieResult;
+              roll.terms[0].results.forEach((die) => {
+                let coloredDieResult;
 
-            if (die.result >= complicationThreshold) {
-              coloredDieResult = `<span style="color: red;">${die.result}</span>`; // Red for complications
-              complications += 1;
-            } else if (die.result <= selectedDisciplineValue) {
-              coloredDieResult = `<span style="color: #6cf542;">${die.result}</span>`; // Green for double successes
-              totalSuccesses += 2;
-            } else if (die.result <= targetNumber && die.result > selectedDisciplineValue) {
-              coloredDieResult = `<span style="color: #42a4f5;">${die.result}</span>`; // Blue for single successes
-              totalSuccesses += 1;
-            } else {
-              coloredDieResult = `<span>${die.result}</span>`; // Default for other results
+                if (die.result >= complicationThreshold) {
+                  coloredDieResult = `<span style="color: red;">${die.result}</span>`; // Red for complications
+                  complications += 1;
+                } else if (die.result <= selectedDisciplineValue) {
+                  coloredDieResult = `<span style="color: #6cf542;">${die.result}</span>`; // Green for double successes
+                  totalSuccesses += 2;
+                } else if (die.result <= targetNumber && die.result > selectedDisciplineValue) {
+                  coloredDieResult = `<span style="color: #42a4f5;">${die.result}</span>`; // Blue for single successes
+                  totalSuccesses += 1;
+                } else {
+                  coloredDieResult = `<span>${die.result}</span>`; // Default for other results
+                }
+                diceResults.push(coloredDieResult);
+              });
+
+              let chatContent = `${game.i18n.format('sta.roll.dicerolls')} ${diceResults.join(', ')}<br>`;
+
+              if (totalSuccesses > NegativeInfluences) {
+                acclaim = totalSuccesses - NegativeInfluences;
+                chatContent += `<strong>${game.i18n.format('sta.roll.gainacclaim', {0: acclaim})}</strong>`;
+              } else if (totalSuccesses < NegativeInfluences) {
+                reprimand = (NegativeInfluences - totalSuccesses) + complications;
+                chatContent += `<strong>${game.i18n.format('sta.roll.gainreprimand', {0: reprimand})}</strong>`;
+              } else if (totalSuccesses === NegativeInfluences) {
+                chatContent += `<strong>${game.i18n.localize('sta.roll.nochange')}</strong>`;
+              }
+
+              ChatMessage.create({
+                speaker: ChatMessage.getSpeaker(),
+                content: chatContent
+              });
             }
-            diceResults.push(coloredDieResult);
-          });
-
-          let chatContent = `${game.i18n.format("sta.roll.dicerolls")} ${diceResults.join(", ")}<br>`;
-
-          if (totalSuccesses > NegativeInfluences) {
-            acclaim = totalSuccesses - NegativeInfluences;
-            chatContent += `<strong>${game.i18n.format("sta.roll.gainacclaim", {0: acclaim})}</strong>`;
-          } else if (totalSuccesses < NegativeInfluences) {
-            reprimand = (NegativeInfluences - totalSuccesses) + complications;
-            chatContent += `<strong>${game.i18n.format("sta.roll.gainreprimand", {0: reprimand})}</strong>`;
-          } else if (totalSuccesses === NegativeInfluences) {
-            chatContent += `<strong>${game.i18n.localize("sta.roll.nochange")}</strong>`;
           }
-
-          ChatMessage.create({
-            speaker: ChatMessage.getSpeaker(),
-            content: chatContent
-          });
+        },
+        render: (html) => {
+          html.find('button').addClass('dialog-button roll default');
         }
-      }
-    },
-    render: (html) => {
-      html.find('button').addClass('dialog-button roll default');
-    }
-  }).render(true);
-});
+      }).render(true);
+    });
 
     // If the check-button is clicked it grabs the selected attribute and the selected discipline and fires the method rollAttributeTest. See actor.js for further info.
     html.find('.check-button.attribute').click((ev) => {

--- a/src/module/actors/sheets/character-sheet.js
+++ b/src/module/actors/sheets/character-sheet.js
@@ -28,7 +28,7 @@ export class STACharacterSheet extends ActorSheet {
   get template() {
     let versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
-    if (!foundry.utils.isNewerVersion(versionInfo,"0.8.-1")) return "systems/sta/templates/actors/character-sheet-legacy.hbs";
+    if (!foundry.utils.isNewerVersion(versionInfo, '0.8.-1')) return 'systems/sta/templates/actors/character-sheet-legacy.hbs';
     return `systems/sta/templates/actors/character-sheet.hbs`;
   }
 
@@ -148,9 +148,8 @@ export class STACharacterSheet extends ActorSheet {
     // This creates a dynamic Stress tracker. It polls for the value of the fitness attribute, security discipline, and checks for Resolute talent. 
     // With the total value, creates a new div for each and places it under a child called "bar-stress-renderer".
     function stressTrackUpdate() {
-
       const localizedValues = {
-        "resolute": game.i18n.localize('sta.actor.character.talents.resolute')
+        'resolute': game.i18n.localize('sta.actor.character.talents.resolute')
       };
 
       stressTrackMax = parseInt(html.find('#fitness')[0].value) + parseInt(html.find('#security')[0].value);
@@ -234,7 +233,7 @@ export class STACharacterSheet extends ActorSheet {
 
     // This toggles whether the value is used or not.
     html.find('.control.toggle').click((ev) => {
-      let itemId = ev.currentTarget.closest(".entry").dataset.itemId;
+      let itemId = ev.currentTarget.closest('.entry').dataset.itemId;
       let item = this.actor.items.get(itemId);
       let state = item.system.used;
       if (state) {

--- a/src/module/actors/sheets/character-sheet.js
+++ b/src/module/actors/sheets/character-sheet.js
@@ -26,7 +26,7 @@ export class STACharacterSheet extends ActorSheet {
   // If the player is not a GM and has limited permissions - send them to the limited sheet, otherwise, continue as usual.
   /** @override */
   get template() {
-    let versionInfo = game.world.coreVersion;
+    const versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
     if (!foundry.utils.isNewerVersion(versionInfo, '0.8.-1')) return 'systems/sta/templates/actors/character-sheet-legacy.hbs';
     return `systems/sta/templates/actors/character-sheet.hbs`;
@@ -56,7 +56,7 @@ export class STACharacterSheet extends ActorSheet {
       if (attribute.value > maxAttribute) attribute.value = maxAttribute; 
       if (attribute.value < minAttribute) attribute.value = minAttribute;
     });
-    let minDiscipline = 0;
+    const minDiscipline = 0;
     let maxDiscipline = 5;
     const overrideDisciplineLimitSetting = game.settings.get('sta', 'characterDisciplineLimitIgnore');
     if (overrideDisciplineLimitSetting) {
@@ -107,7 +107,7 @@ export class STACharacterSheet extends ActorSheet {
     super.activateListeners(html);
     
     // Allows checking version easily
-    let versionInfo = game.world.coreVersion;
+    const versionInfo = game.world.coreVersion;
 
     // Opens the class STASharedActorFunctions for access at various stages.
     const staActor = new STASharedActorFunctions();
@@ -233,9 +233,9 @@ export class STACharacterSheet extends ActorSheet {
 
     // This toggles whether the value is used or not.
     html.find('.control.toggle').click((ev) => {
-      let itemId = ev.currentTarget.closest('.entry').dataset.itemId;
-      let item = this.actor.items.get(itemId);
-      let state = item.system.used;
+      const itemId = ev.currentTarget.closest('.entry').dataset.itemId;
+      const item = this.actor.items.get(itemId);
+      const state = item.system.used;
       if (state) {
         item.system.used = false;
         $(ev.currentTarget).children()[0].classList.remove('fa-toggle-on');

--- a/src/module/actors/sheets/character-sheet2e.js
+++ b/src/module/actors/sheets/character-sheet2e.js
@@ -28,7 +28,7 @@ export class STACharacterSheet2e extends ActorSheet {
   get template() {
     let versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
-    if (!foundry.utils.isNewerVersion(versionInfo,"0.8.-1")) return "systems/sta/templates/actors/character-sheet-legacy.hbs";
+    if (!foundry.utils.isNewerVersion(versionInfo, "0.8.-1")) return "systems/sta/templates/actors/character-sheet-legacy.hbs";
     return `systems/sta/templates/actors/character-sheet2e.hbs`;
   }
 
@@ -148,7 +148,6 @@ export class STACharacterSheet2e extends ActorSheet {
     // This creates a dynamic Stress tracker. It polls for the value of the fitness attribute and checks for Resolute and tough talent. 
     // With the total value, creates a new div for each and places it under a child called "bar-stress-renderer".
     function stressTrackUpdate() {
-
       const localizedValues = {
         "tough": game.i18n.localize('sta.actor.character.talents.tough'),
         "resolute": game.i18n.localize('sta.actor.character.talents.resolute'),
@@ -489,91 +488,89 @@ export class STACharacterSheet2e extends ActorSheet {
     });
 
 
-  // If the check-button is clicked it performs the acclaim or reprimand calculation.
-html.find('.check-button.acclaim').click(async (ev) => {
+    // If the check-button is clicked it performs the acclaim or reprimand calculation.
+    html.find('.check-button.acclaim').click(async (ev) => {
+      let dialogContent = `
+        <form class="sta-form">
+            <div class="dice-pool flexcol">
+                <div class="flexrow">
+                    <div style="flex:80%;"><label class="label">${game.i18n.localize('sta.roll.positiveinfluences')}</label></div>
+                    <input type="number" name="positiveInfluences" value="1" class="numeric-entry" id="positiveInfluences">
+                </div>
+                <div class="flexrow">
+                    <div style="flex:80%;"><label class="label">${game.i18n.localize('sta.roll.negativeinfluences')}</label></div>
+                    <input type="number" name="negativeInfluences" value="0" class="numeric-entry" id="negativeInfluences">
+                </div>
+            </div>    
+        </form>`;
 
-  let dialogContent = `
-  <form class="sta-form">
-      <div class="dice-pool flexcol">
-          <div class="flexrow">
-              <div style="flex:80%;"><label class="label">${game.i18n.localize('sta.roll.positiveinfluences')}</label></div>
-              <input type="number" name="positiveInfluences" value="1" class="numeric-entry" id="positiveInfluences">
-          </div>
-          <div class="flexrow">
-              <div style="flex:80%;"><label class="label">${game.i18n.localize('sta.roll.negativeinfluences')}</label></div>
-              <input type="number" name="negativeInfluences" value="0" class="numeric-entry" id="negativeInfluences">
-          </div>
-      </div>    
-  </form>
-  `;
+      new Dialog({
+        title: `${game.i18n.localize('sta.roll.acclaim')}`,
+        content: dialogContent,
+        buttons: {
+          roll: {
+            label: `${game.i18n.localize('sta.roll.acclaim')}`,
+            callback: async (html) => {
+              let PositiveInfluences = parseInt(html.find('#positiveInfluences').val()) || 1;
+              let NegativeInfluences = parseInt(html.find('#negativeInfluences').val()) || 0;
 
-  new Dialog({
-    title: `${game.i18n.localize('sta.roll.acclaim')}`,
-    content: dialogContent,
-    buttons: {
-      roll: {
-        label: `${game.i18n.localize('sta.roll.acclaim')}`,
-        callback: async (html) => {
-          let PositiveInfluences = parseInt(html.find('#positiveInfluences').val()) || 1;
-          let NegativeInfluences = parseInt(html.find('#negativeInfluences').val()) || 0;
-          
-          let selectedDisciplineValue = parseInt(document.querySelector('#total-rep')?.value) || 0;
-          let existingReprimand = parseInt(document.querySelector('#reprimand')?.value) || 0;
-          let targetNumber = selectedDisciplineValue + 7;
-          let complicationThreshold = 20 - Math.min(existingReprimand, 5);
-          let diceRollFormula = `${PositiveInfluences}d20`;
-          let roll = new Roll(diceRollFormula);
+              let selectedDisciplineValue = parseInt(document.querySelector('#total-rep')?.value) || 0;
+              let existingReprimand = parseInt(document.querySelector('#reprimand')?.value) || 0;
+              let targetNumber = selectedDisciplineValue + 7;
+              let complicationThreshold = 20 - Math.min(existingReprimand, 5);
+              let diceRollFormula = `${PositiveInfluences}d20`;
+              let roll = new Roll(diceRollFormula);
 
-          await roll.evaluate();
+              await roll.evaluate();
 
-          let totalSuccesses = 0;
-          let complications = 0;
-          let acclaim = 0;
-          let reprimand = 0;
-          let diceResults = [];
+              let totalSuccesses = 0;
+              let complications = 0;
+              let acclaim = 0;
+              let reprimand = 0;
+              let diceResults = [];
 
-          roll.terms[0].results.forEach(die => {
-            let coloredDieResult;
+              roll.terms[0].results.forEach(die => {
+                let coloredDieResult;
 
-            if (die.result >= complicationThreshold) {
-              coloredDieResult = `<span style="color: red;">${die.result}</span>`; // Red for complications
-              complications += 1;
-            } else if (die.result <= selectedDisciplineValue) {
-              coloredDieResult = `<span style="color: #6cf542;">${die.result}</span>`; // Green for double successes
-              totalSuccesses += 2;
-            } else if (die.result <= targetNumber && die.result > selectedDisciplineValue) {
-              coloredDieResult = `<span style="color: #42a4f5;">${die.result}</span>`; // Blue for single successes
-              totalSuccesses += 1;
-            } else {
-              coloredDieResult = `<span>${die.result}</span>`; // Default for other results
+                if (die.result >= complicationThreshold) {
+                  coloredDieResult = `<span style="color: red;">${die.result}</span>`; // Red for complications
+                  complications += 1;
+                } else if (die.result <= selectedDisciplineValue) {
+                  coloredDieResult = `<span style="color: #6cf542;">${die.result}</span>`; // Green for double successes
+                  totalSuccesses += 2;
+                } else if (die.result <= targetNumber && die.result > selectedDisciplineValue) {
+                  coloredDieResult = `<span style="color: #42a4f5;">${die.result}</span>`; // Blue for single successes
+                  totalSuccesses += 1;
+                } else {
+                  coloredDieResult = `<span>${die.result}</span>`; // Default for other results
+                }
+                diceResults.push(coloredDieResult);
+              });
+
+              let chatContent = `${game.i18n.format("sta.roll.dicerolls")} ${diceResults.join(", ")}<br>`;
+
+              if (totalSuccesses > NegativeInfluences) {
+                acclaim = totalSuccesses - NegativeInfluences;
+                chatContent += `<strong>${game.i18n.format("sta.roll.gainacclaim", {0: acclaim})}</strong>`;
+              } else if (totalSuccesses < NegativeInfluences) {
+                reprimand = (NegativeInfluences - totalSuccesses) + complications;
+                chatContent += `<strong>${game.i18n.format("sta.roll.gainreprimand", {0: reprimand})}</strong>`;
+              } else if (totalSuccesses === NegativeInfluences) {
+                chatContent += `<strong>${game.i18n.localize("sta.roll.nochange")}</strong>`;
+              }
+
+              ChatMessage.create({
+                speaker: ChatMessage.getSpeaker(),
+                content: chatContent
+              });
             }
-            diceResults.push(coloredDieResult);
-          });
-
-          let chatContent = `${game.i18n.format("sta.roll.dicerolls")} ${diceResults.join(", ")}<br>`;
-
-          if (totalSuccesses > NegativeInfluences) {
-            acclaim = totalSuccesses - NegativeInfluences;
-            chatContent += `<strong>${game.i18n.format("sta.roll.gainacclaim", {0: acclaim})}</strong>`;
-          } else if (totalSuccesses < NegativeInfluences) {
-            reprimand = (NegativeInfluences - totalSuccesses) + complications;
-            chatContent += `<strong>${game.i18n.format("sta.roll.gainreprimand", {0: reprimand})}</strong>`;
-          } else if (totalSuccesses === NegativeInfluences) {
-            chatContent += `<strong>${game.i18n.localize("sta.roll.nochange")}</strong>`;
           }
-
-          ChatMessage.create({
-            speaker: ChatMessage.getSpeaker(),
-            content: chatContent
-          });
+        },
+        render: (html) => {
+          html.find('button').addClass('dialog-button roll default');
         }
-      }
-    },
-    render: (html) => {
-      html.find('button').addClass('dialog-button roll default');
-    }
-  }).render(true);
-});
+      }).render(true);
+    });
 
     // If the check-button is clicked it grabs the selected attribute and the selected discipline and fires the method rollAttributeTest. See actor.js for further info.
     html.find('.check-button.attribute').click((ev) => {
@@ -594,10 +591,10 @@ html.find('.check-button.acclaim').click(async (ev) => {
           selectedDiscipline = selectedDiscipline.slice(0, -9);
           selectedDisciplineValue = html.find('#'+selectedDiscipline)[0].value;
         }
-       if (html.find('input[name="system.rollrepnotdis"]')[0].checked) {
-         selectedDiscipline = 'reputation';
-         selectedDisciplineValue = html.find('#total-rep')[0].value;
-       }
+        if (html.find('input[name="system.rollrepnotdis"]')[0].checked) {
+          selectedDiscipline = 'reputation';
+          selectedDisciplineValue = html.find('#total-rep')[0].value;
+        }
       }
             
       staActor.rollAttributeTest(ev, selectedAttribute,

--- a/src/module/actors/sheets/character-sheet2e.js
+++ b/src/module/actors/sheets/character-sheet2e.js
@@ -41,7 +41,9 @@ export class STACharacterSheet2e extends ActorSheet {
 	
     // Temporary fix I'm leaving in place until I deprecate in a future version
     const overrideMinAttributeTags = ['[Minor]', '[Notable]', '[Major]', '[NPC]', '[Child]'];
-    const overrideMinAttribute = overrideMinAttributeTags.some((tag) => sheetData.name.toLowerCase().indexOf(tag.toLowerCase()) !== -1);
+    const overrideMinAttribute = overrideMinAttributeTags.some(
+      (tag) => sheetData.name.toLowerCase().indexOf(tag.toLowerCase()) !== -1
+    );
     
 
     // Ensure attribute and discipline values aren't over the max/min.

--- a/src/module/actors/sheets/character-sheet2e.js
+++ b/src/module/actors/sheets/character-sheet2e.js
@@ -68,8 +68,9 @@ export class STACharacterSheet2e extends ActorSheet {
     });
 
     // Check stress max/min
-    if (!(sheetData.system.stress))
+    if (!(sheetData.system.stress)) {
       sheetData.system.stress = {};
+    }
     if (sheetData.system.stress.value > sheetData.system.stress.max) {
       sheetData.system.stress.value = sheetData.system.stress.max;
     }
@@ -78,8 +79,9 @@ export class STACharacterSheet2e extends ActorSheet {
     }
 
     // Check determination max/min
-    if (!(sheetData.system.determination))
+    if (!(sheetData.system.determination)) {
       sheetData.system.determination = {};
+    }
     if (sheetData.system.determination.value > 3) {
       sheetData.system.determination.value = 3;
     }
@@ -88,8 +90,9 @@ export class STACharacterSheet2e extends ActorSheet {
     }
     
     // Check reputation max/min
-    if (!(sheetData.system.reputation))
+    if (!(sheetData.system.reputation)) {
       sheetData.system.reputation = {};
+    }
     if (sheetData.system.reputation.value > 5) {
       sheetData.system.reputation.value = 5;
     }
@@ -154,7 +157,7 @@ export class STACharacterSheet2e extends ActorSheet {
         'mentaldiscipline': game.i18n.localize('sta.actor.character.talents.mentaldiscipline')
       };
 
-      stressTrackMax = parseInt(html.find('#fitness')[0].value)
+      stressTrackMax = parseInt(html.find('#fitness')[0].value);
       if (html.find(`[data-talent-name*="${localizedValues.mentaldiscipline}"]`).length > 0) {
         stressTrackMax = parseInt(html.find('#control')[0].value);
 	  }
@@ -164,7 +167,7 @@ export class STACharacterSheet2e extends ActorSheet {
       if (html.find(`[data-talent-name*="${localizedValues.resolute}"]`).length > 0) {
         stressTrackMax += parseInt(html.find('#command')[0].value);
       }
-	  stressTrackMax += parseInt(html.find('#strmod')[0].value)
+	  stressTrackMax += parseInt(html.find('#strmod')[0].value);
       // This checks that the max-stress hidden field is equal to the calculated Max Stress value, if not it makes it so.
       if (html.find('#max-stress')[0].value != stressTrackMax) {
         html.find('#max-stress')[0].value = stressTrackMax;
@@ -529,7 +532,7 @@ export class STACharacterSheet2e extends ActorSheet {
               let reprimand = 0;
               const diceResults = [];
 
-              roll.terms[0].results.forEach(die => {
+              roll.terms[0].results.forEach((die) => {
                 let coloredDieResult;
 
                 if (die.result >= complicationThreshold) {

--- a/src/module/actors/sheets/character-sheet2e.js
+++ b/src/module/actors/sheets/character-sheet2e.js
@@ -26,7 +26,7 @@ export class STACharacterSheet2e extends ActorSheet {
   // If the player is not a GM and has limited permissions - send them to the limited sheet, otherwise, continue as usual.
   /** @override */
   get template() {
-    let versionInfo = game.world.coreVersion;
+    const versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
     if (!foundry.utils.isNewerVersion(versionInfo, '0.8.-1')) return 'systems/sta/templates/actors/character-sheet-legacy.hbs';
     return `systems/sta/templates/actors/character-sheet2e.hbs`;
@@ -56,7 +56,7 @@ export class STACharacterSheet2e extends ActorSheet {
       if (attribute.value > maxAttribute) attribute.value = maxAttribute; 
       if (attribute.value < minAttribute) attribute.value = minAttribute;
     });
-    let minDiscipline = 0;
+    const minDiscipline = 0;
     let maxDiscipline = 5;
     const overrideDisciplineLimitSetting = game.settings.get('sta', 'characterDisciplineLimitIgnore');
     if (overrideDisciplineLimitSetting) {
@@ -107,7 +107,7 @@ export class STACharacterSheet2e extends ActorSheet {
     super.activateListeners(html);
     
     // Allows checking version easily
-    let versionInfo = game.world.coreVersion;
+    const versionInfo = game.world.coreVersion;
 
     // Opens the class STASharedActorFunctions for access at various stages.
     const staActor = new STASharedActorFunctions();
@@ -241,9 +241,9 @@ export class STACharacterSheet2e extends ActorSheet {
 
     // This toggles whether the value is used or not.
     html.find('.control.toggle').click((ev) => {
-      let itemId = ev.currentTarget.closest('.entry').dataset.itemId;
-      let item = this.actor.items.get(itemId);
-      let state = item.system.used;
+      const itemId = ev.currentTarget.closest('.entry').dataset.itemId;
+      const item = this.actor.items.get(itemId);
+      const state = item.system.used;
       if (state) {
         item.system.used = false;
         $(ev.currentTarget).children()[0].classList.remove('fa-toggle-on');
@@ -490,7 +490,7 @@ export class STACharacterSheet2e extends ActorSheet {
 
     // If the check-button is clicked it performs the acclaim or reprimand calculation.
     html.find('.check-button.acclaim').click(async (ev) => {
-      let dialogContent = `
+      const dialogContent = `
         <form class="sta-form">
             <div class="dice-pool flexcol">
                 <div class="flexrow">
@@ -511,15 +511,15 @@ export class STACharacterSheet2e extends ActorSheet {
           roll: {
             label: `${game.i18n.localize('sta.roll.acclaim')}`,
             callback: async (html) => {
-              let PositiveInfluences = parseInt(html.find('#positiveInfluences').val()) || 1;
-              let NegativeInfluences = parseInt(html.find('#negativeInfluences').val()) || 0;
+              const PositiveInfluences = parseInt(html.find('#positiveInfluences').val()) || 1;
+              const NegativeInfluences = parseInt(html.find('#negativeInfluences').val()) || 0;
 
-              let selectedDisciplineValue = parseInt(document.querySelector('#total-rep')?.value) || 0;
-              let existingReprimand = parseInt(document.querySelector('#reprimand')?.value) || 0;
-              let targetNumber = selectedDisciplineValue + 7;
-              let complicationThreshold = 20 - Math.min(existingReprimand, 5);
-              let diceRollFormula = `${PositiveInfluences}d20`;
-              let roll = new Roll(diceRollFormula);
+              const selectedDisciplineValue = parseInt(document.querySelector('#total-rep')?.value) || 0;
+              const existingReprimand = parseInt(document.querySelector('#reprimand')?.value) || 0;
+              const targetNumber = selectedDisciplineValue + 7;
+              const complicationThreshold = 20 - Math.min(existingReprimand, 5);
+              const diceRollFormula = `${PositiveInfluences}d20`;
+              const roll = new Roll(diceRollFormula);
 
               await roll.evaluate();
 
@@ -527,7 +527,7 @@ export class STACharacterSheet2e extends ActorSheet {
               let complications = 0;
               let acclaim = 0;
               let reprimand = 0;
-              let diceResults = [];
+              const diceResults = [];
 
               roll.terms[0].results.forEach(die => {
                 let coloredDieResult;

--- a/src/module/actors/sheets/character-sheet2e.js
+++ b/src/module/actors/sheets/character-sheet2e.js
@@ -28,7 +28,7 @@ export class STACharacterSheet2e extends ActorSheet {
   get template() {
     let versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
-    if (!foundry.utils.isNewerVersion(versionInfo, "0.8.-1")) return "systems/sta/templates/actors/character-sheet-legacy.hbs";
+    if (!foundry.utils.isNewerVersion(versionInfo, '0.8.-1')) return 'systems/sta/templates/actors/character-sheet-legacy.hbs';
     return `systems/sta/templates/actors/character-sheet2e.hbs`;
   }
 
@@ -149,9 +149,9 @@ export class STACharacterSheet2e extends ActorSheet {
     // With the total value, creates a new div for each and places it under a child called "bar-stress-renderer".
     function stressTrackUpdate() {
       const localizedValues = {
-        "tough": game.i18n.localize('sta.actor.character.talents.tough'),
-        "resolute": game.i18n.localize('sta.actor.character.talents.resolute'),
-        "mentaldiscipline": game.i18n.localize('sta.actor.character.talents.mentaldiscipline')
+        'tough': game.i18n.localize('sta.actor.character.talents.tough'),
+        'resolute': game.i18n.localize('sta.actor.character.talents.resolute'),
+        'mentaldiscipline': game.i18n.localize('sta.actor.character.talents.mentaldiscipline')
       };
 
       stressTrackMax = parseInt(html.find('#fitness')[0].value)
@@ -241,7 +241,7 @@ export class STACharacterSheet2e extends ActorSheet {
 
     // This toggles whether the value is used or not.
     html.find('.control.toggle').click((ev) => {
-      let itemId = ev.currentTarget.closest(".entry").dataset.itemId;
+      let itemId = ev.currentTarget.closest('.entry').dataset.itemId;
       let item = this.actor.items.get(itemId);
       let state = item.system.used;
       if (state) {
@@ -547,16 +547,16 @@ export class STACharacterSheet2e extends ActorSheet {
                 diceResults.push(coloredDieResult);
               });
 
-              let chatContent = `${game.i18n.format("sta.roll.dicerolls")} ${diceResults.join(", ")}<br>`;
+              let chatContent = `${game.i18n.format('sta.roll.dicerolls')} ${diceResults.join(', ')}<br>`;
 
               if (totalSuccesses > NegativeInfluences) {
                 acclaim = totalSuccesses - NegativeInfluences;
-                chatContent += `<strong>${game.i18n.format("sta.roll.gainacclaim", {0: acclaim})}</strong>`;
+                chatContent += `<strong>${game.i18n.format('sta.roll.gainacclaim', {0: acclaim})}</strong>`;
               } else if (totalSuccesses < NegativeInfluences) {
                 reprimand = (NegativeInfluences - totalSuccesses) + complications;
-                chatContent += `<strong>${game.i18n.format("sta.roll.gainreprimand", {0: reprimand})}</strong>`;
+                chatContent += `<strong>${game.i18n.format('sta.roll.gainreprimand', {0: reprimand})}</strong>`;
               } else if (totalSuccesses === NegativeInfluences) {
-                chatContent += `<strong>${game.i18n.localize("sta.roll.nochange")}</strong>`;
+                chatContent += `<strong>${game.i18n.localize('sta.roll.nochange')}</strong>`;
               }
 
               ChatMessage.create({

--- a/src/module/actors/sheets/smallcraft-sheet.js
+++ b/src/module/actors/sheets/smallcraft-sheet.js
@@ -22,7 +22,7 @@ export class STASmallCraftSheet extends ActorSheet {
   get template() {
     let versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
-    if (!foundry.utils.isNewerVersion(versionInfo, "0.8.-1")) return "systems/sta/templates/actors/smallcraft-sheet-legacy.hbs";
+    if (!foundry.utils.isNewerVersion(versionInfo, '0.8.-1')) return 'systems/sta/templates/actors/smallcraft-sheet-legacy.hbs';
     return `systems/sta/templates/actors/smallcraft-sheet.hbs`;
   }
     
@@ -94,7 +94,7 @@ export class STASmallCraftSheet extends ActorSheet {
     function shieldsTrackUpdate() {
 
       const localizedValues = {
-        "advancedshields": game.i18n.localize('sta.actor.starship.talents.advancedshields')
+        'advancedshields': game.i18n.localize('sta.actor.starship.talents.advancedshields')
       };
 
       shieldsTrackMax = Math.floor((parseInt(html.find('#structure')[0].value) + parseInt(html.find('#security')[0].value))/2) + parseInt(html.find('#shieldmod')[0].value);
@@ -411,7 +411,7 @@ export class STASmallCraftSheet extends ActorSheet {
       const weaponDamage = parseInt(value.dataset.itemDamage);
       const securityValue = parseInt(html.find('#security')[0].value);
       let scaleDamage = 0;
-      if (value.dataset.itemIncludescale == "true") scaleDamage = parseInt(html.find('#scale')[0].value);
+      if (value.dataset.itemIncludescale == 'true') scaleDamage = parseInt(html.find('#scale')[0].value);
       const attackDamageValue = weaponDamage + securityValue + scaleDamage;
       value.getElementsByClassName('damage')[0].innerText = attackDamageValue;
     });

--- a/src/module/actors/sheets/smallcraft-sheet.js
+++ b/src/module/actors/sheets/smallcraft-sheet.js
@@ -22,7 +22,7 @@ export class STASmallCraftSheet extends ActorSheet {
   get template() {
     let versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
-    if (!foundry.utils.isNewerVersion(versionInfo,"0.8.-1")) return "systems/sta/templates/actors/smallcraft-sheet-legacy.hbs";
+    if (!foundry.utils.isNewerVersion(versionInfo, "0.8.-1")) return "systems/sta/templates/actors/smallcraft-sheet-legacy.hbs";
     return `systems/sta/templates/actors/smallcraft-sheet.hbs`;
   }
     

--- a/src/module/actors/sheets/smallcraft-sheet.js
+++ b/src/module/actors/sheets/smallcraft-sheet.js
@@ -20,7 +20,7 @@ export class STASmallCraftSheet extends ActorSheet {
   // If the player is not a GM and has limited permissions - send them to the limited sheet, otherwise, continue as usual.
   /** @override */
   get template() {
-    let versionInfo = game.world.coreVersion;
+    const versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
     if (!foundry.utils.isNewerVersion(versionInfo, '0.8.-1')) return 'systems/sta/templates/actors/smallcraft-sheet-legacy.hbs';
     return `systems/sta/templates/actors/smallcraft-sheet.hbs`;
@@ -74,7 +74,7 @@ export class STASmallCraftSheet extends ActorSheet {
     super.activateListeners(html);
     
     // Allows checking version easily 
-    let versionInfo = game.world.coreVersion; 
+    const versionInfo = game.world.coreVersion;
     
     // Opens the class STASharedActorFunctions for access at various stages.
     const staActor = new STASharedActorFunctions();

--- a/src/module/actors/sheets/smallcraft-sheet.js
+++ b/src/module/actors/sheets/smallcraft-sheet.js
@@ -92,7 +92,6 @@ export class STASmallCraftSheet extends ActorSheet {
     // This creates a dynamic Shields tracker. It polls for the value of the structure system and security department. 
     // With the total value divided by 2, creates a new div for each and places it under a child called "bar-shields-renderer".
     function shieldsTrackUpdate() {
-
       const localizedValues = {
         'advancedshields': game.i18n.localize('sta.actor.starship.talents.advancedshields')
       };

--- a/src/module/actors/sheets/smallcraft-sheet2e.js
+++ b/src/module/actors/sheets/smallcraft-sheet2e.js
@@ -22,7 +22,7 @@ export class STASmallCraftSheet2e extends ActorSheet {
   get template() {
     let versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
-    if (!foundry.utils.isNewerVersion(versionInfo,"0.8.-1")) return "systems/sta/templates/actors/smallcraft-sheet-legacy.hbs";
+    if (!foundry.utils.isNewerVersion(versionInfo, "0.8.-1")) return "systems/sta/templates/actors/smallcraft-sheet-legacy.hbs";
     return `systems/sta/templates/actors/smallcraft-sheet2e.hbs`;
   }
     
@@ -125,10 +125,10 @@ export class STASmallCraftSheet2e extends ActorSheet {
     // With the value, creates a new div for each and places it under a child called "bar-power-renderer".
     function powerTrackUpdate() {
       powerTrackMax = 0;
-//      powerTrackMax = Math.ceil(parseInt(html.find('#engines')[0].value)/2);
-//      if (html.find('[data-talent-name*="Secondary Reactors"]').length > 0) {
-//        powerTrackMax += 5;
-//      }
+      // powerTrackMax = Math.ceil(parseInt(html.find('#engines')[0].value)/2);
+      // if (html.find('[data-talent-name*="Secondary Reactors"]').length > 0) {
+      // powerTrackMax += 5;
+      // }
       // This checks that the max-power hidden field is equal to the calculated Max Power value, if not it makes it so.
       if (html.find('#max-power')[0].value != powerTrackMax) {
         html.find('#max-power')[0].value = powerTrackMax;
@@ -435,25 +435,25 @@ export class STASmallCraftSheet2e extends ActorSheet {
       const shipScaleValue = Number.parseInt(html.find('#scale').attr('value'));
       let totalBreaches = 0;
 
-    html.find('.selector.system').each(function(index, value) {
-      const $systemCheckbox = $(value);
-      const $systemBreach = $systemCheckbox.siblings('.breaches');
-      const breachValue = Number.parseInt($systemBreach.attr('value'));
+      html.find('.selector.system').each(function(index, value) {
+        const $systemCheckbox = $(value);
+        const $systemBreach = $systemCheckbox.siblings('.breaches');
+        const breachValue = Number.parseInt($systemBreach.attr('value'));
 
-      totalBreaches += breachValue;
+        totalBreaches += breachValue;
 
-      const isSystemDestroyed = breachValue >= (Math.ceil(shipScaleValue / 2)) ? true : false;
+        const isSystemDestroyed = breachValue >= (Math.ceil(shipScaleValue / 2)) ? true : false;
 
-      if (breachValue > 0 && !isSystemDestroyed) {
-        $systemBreach.addClass('highlight-damaged');
-        $systemBreach.removeClass('highlight-destroyed');
-      } else if (isSystemDestroyed) {
-        $systemBreach.addClass('highlight-destroyed');
-        $systemBreach.removeClass('highlight-damaged');
-      } else {
-        $systemBreach.removeClass('highlight-damaged highlight-disabled highlight-destroyed');
-      }
-    });
+        if (breachValue > 0 && !isSystemDestroyed) {
+          $systemBreach.addClass('highlight-damaged');
+          $systemBreach.removeClass('highlight-destroyed');
+        } else if (isSystemDestroyed) {
+          $systemBreach.addClass('highlight-destroyed');
+          $systemBreach.removeClass('highlight-damaged');
+        } else {
+          $systemBreach.removeClass('highlight-damaged highlight-disabled highlight-destroyed');
+        }
+      });
 
       if (totalBreaches === (shipScaleValue + 1)) {
         sheetElement.addClass('highlight-damaged');

--- a/src/module/actors/sheets/smallcraft-sheet2e.js
+++ b/src/module/actors/sheets/smallcraft-sheet2e.js
@@ -20,7 +20,7 @@ export class STASmallCraftSheet2e extends ActorSheet {
   // If the player is not a GM and has limited permissions - send them to the limited sheet, otherwise, continue as usual.
   /** @override */
   get template() {
-    let versionInfo = game.world.coreVersion;
+    const versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
     if (!foundry.utils.isNewerVersion(versionInfo, '0.8.-1')) return 'systems/sta/templates/actors/smallcraft-sheet-legacy.hbs';
     return `systems/sta/templates/actors/smallcraft-sheet2e.hbs`;
@@ -74,7 +74,7 @@ export class STASmallCraftSheet2e extends ActorSheet {
     super.activateListeners(html);
     
     // Allows checking version easily 
-    let versionInfo = game.world.coreVersion; 
+    const versionInfo = game.world.coreVersion; 
     
     // Opens the class STASharedActorFunctions for access at various stages.
     const staActor = new STASharedActorFunctions();
@@ -429,8 +429,8 @@ export class STASmallCraftSheet2e extends ActorSheet {
     });
 
     Hooks.on('renderSTASmallCraftSheet2e', (app, html, data) => {
-      let sheetId = app.id;
-      let sheetElement = $(`#${sheetId} .main`);
+      const sheetId = app.id;
+      const sheetElement = $(`#${sheetId} .main`);
 
       const shipScaleValue = Number.parseInt(html.find('#scale').attr('value'));
       let totalBreaches = 0;

--- a/src/module/actors/sheets/smallcraft-sheet2e.js
+++ b/src/module/actors/sheets/smallcraft-sheet2e.js
@@ -22,7 +22,7 @@ export class STASmallCraftSheet2e extends ActorSheet {
   get template() {
     let versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
-    if (!foundry.utils.isNewerVersion(versionInfo, "0.8.-1")) return "systems/sta/templates/actors/smallcraft-sheet-legacy.hbs";
+    if (!foundry.utils.isNewerVersion(versionInfo, '0.8.-1')) return 'systems/sta/templates/actors/smallcraft-sheet-legacy.hbs';
     return `systems/sta/templates/actors/smallcraft-sheet2e.hbs`;
   }
     
@@ -94,8 +94,8 @@ export class STASmallCraftSheet2e extends ActorSheet {
     function shieldsTrackUpdate() {
 
       const localizedValues = {
-        "advancedshields": game.i18n.localize('sta.actor.starship.talents.advancedshields'),
-        "polarizedhullplating": game.i18n.localize('sta.actor.starship.talents.polarizedhullplating')
+        'advancedshields': game.i18n.localize('sta.actor.starship.talents.advancedshields'),
+        'polarizedhullplating': game.i18n.localize('sta.actor.starship.talents.polarizedhullplating')
       };
 
       shieldsTrackMax = parseInt(html.find('#structure')[0].value) + parseInt(html.find('#security')[0].value) + parseInt(html.find('#scale')[0].value) + parseInt(html.find('#shieldmod')[0].value);
@@ -103,7 +103,7 @@ export class STASmallCraftSheet2e extends ActorSheet {
         shieldsTrackMax += 5;
       }
       if (html.find(`[data-talent-name*="${localizedValues.polarizedhullplating}"]`).length > 0) {
-        shieldsTrackMax = parseInt(html.find('#structure')[0].value) + parseInt(html.find('#shieldmod')[0].value)
+        shieldsTrackMax = parseInt(html.find('#structure')[0].value) + parseInt(html.find('#shieldmod')[0].value);
       }
       // This checks that the max-shields hidden field is equal to the calculated Max Shields value, if not it makes it so.
       if (html.find('#max-shields')[0].value != shieldsTrackMax) {
@@ -422,7 +422,7 @@ export class STASmallCraftSheet2e extends ActorSheet {
       if (parseInt(html.find('#weapons')[0].value) > 12) weaponValue = 4;
 
       let scaleDamage = 0;
-      if (value.dataset.itemIncludescale == "energy") scaleDamage = parseInt(html.find('#scale')[0].value);
+      if (value.dataset.itemIncludescale == 'energy') scaleDamage = parseInt(html.find('#scale')[0].value);
 
       const attackDamageValue = weaponDamage + weaponValue + scaleDamage;
       value.getElementsByClassName('damage')[0].innerText = attackDamageValue;

--- a/src/module/actors/sheets/smallcraft-sheet2e.js
+++ b/src/module/actors/sheets/smallcraft-sheet2e.js
@@ -92,7 +92,6 @@ export class STASmallCraftSheet2e extends ActorSheet {
     // This creates a dynamic Shields tracker. It polls for the value of the structure system and security department. 
     // With the total value divided by 2, creates a new div for each and places it under a child called "bar-shields-renderer".
     function shieldsTrackUpdate() {
-
       const localizedValues = {
         'advancedshields': game.i18n.localize('sta.actor.starship.talents.advancedshields'),
         'polarizedhullplating': game.i18n.localize('sta.actor.starship.talents.polarizedhullplating')

--- a/src/module/actors/sheets/starship-sheet.js
+++ b/src/module/actors/sheets/starship-sheet.js
@@ -3,12 +3,15 @@ import {
 } from '../actor.js';
 
 export class STAStarshipSheet extends ActorSheet {
+  constructor(object, options={}) {
+    super(object, options);
 
-  /**
-   * An actively open dialog that should be closed before a new one is opened.
-   * @type {Dialog}
-   */
-  activeDialog;
+    /**
+     * An actively open dialog that should be closed before a new one is opened.
+     * @type {Dialog}
+     */
+    this.activeDialog = null;
+  }
 
   /** @override */
   static get defaultOptions() {

--- a/src/module/actors/sheets/starship-sheet.js
+++ b/src/module/actors/sheets/starship-sheet.js
@@ -29,7 +29,7 @@ export class STAStarshipSheet extends ActorSheet {
   get template() {
     let versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
-    if (!foundry.utils.isNewerVersion(versionInfo, "0.8.-1")) return "systems/sta/templates/actors/starship-sheet-legacy.hbs";
+    if (!foundry.utils.isNewerVersion(versionInfo, '0.8.-1')) return 'systems/sta/templates/actors/starship-sheet-legacy.hbs';
     return `systems/sta/templates/actors/starship-sheet.hbs`;
   }
 
@@ -107,7 +107,7 @@ export class STAStarshipSheet extends ActorSheet {
     // With the total value, creates a new div for each and places it under a child called "bar-shields-renderer".
     function shieldsTrackUpdate() {
       const localizedValues = {
-        "advancedshields": game.i18n.localize('sta.actor.starship.talents.advancedshields')
+        'advancedshields': game.i18n.localize('sta.actor.starship.talents.advancedshields')
       };
 
       shieldsTrackMax = parseInt(html.find('#structure')[0].value) + parseInt(html.find('#security')[0].value) + parseInt(html.find('#shieldmod')[0].value);
@@ -481,7 +481,7 @@ export class STAStarshipSheet extends ActorSheet {
       const weaponDamage = parseInt(value.dataset.itemDamage);
       const securityValue = parseInt(html.find('#security')[0].value);
       let scaleDamage = 0;
-      if (value.dataset.itemIncludescale == "true") scaleDamage = parseInt(html.find('#scale')[0].value);
+      if (value.dataset.itemIncludescale == 'true') scaleDamage = parseInt(html.find('#scale')[0].value);
       const attackDamageValue = weaponDamage + securityValue + scaleDamage;
       value.getElementsByClassName('damage')[0].innerText = attackDamageValue;
     });

--- a/src/module/actors/sheets/starship-sheet.js
+++ b/src/module/actors/sheets/starship-sheet.js
@@ -27,7 +27,7 @@ export class STAStarshipSheet extends ActorSheet {
   // If the player is not a GM and has limited permissions - send them to the limited sheet, otherwise, continue as usual.
   /** @override */
   get template() {
-    let versionInfo = game.world.coreVersion;
+    const versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
     if (!foundry.utils.isNewerVersion(versionInfo, '0.8.-1')) return 'systems/sta/templates/actors/starship-sheet-legacy.hbs';
     return `systems/sta/templates/actors/starship-sheet.hbs`;
@@ -89,7 +89,7 @@ export class STAStarshipSheet extends ActorSheet {
     super.activateListeners(html);
     
     // Allows checking version easily 
-    let versionInfo = game.world.coreVersion; 
+    const versionInfo = game.world.coreVersion;
 
     // Opens the class STASharedActorFunctions for access at various stages.
     const staActor = new STASharedActorFunctions();

--- a/src/module/actors/sheets/starship-sheet.js
+++ b/src/module/actors/sheets/starship-sheet.js
@@ -29,7 +29,7 @@ export class STAStarshipSheet extends ActorSheet {
   get template() {
     let versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
-    if (!foundry.utils.isNewerVersion(versionInfo,"0.8.-1")) return "systems/sta/templates/actors/starship-sheet-legacy.hbs";
+    if (!foundry.utils.isNewerVersion(versionInfo, "0.8.-1")) return "systems/sta/templates/actors/starship-sheet-legacy.hbs";
     return `systems/sta/templates/actors/starship-sheet.hbs`;
   }
 
@@ -106,7 +106,6 @@ export class STAStarshipSheet extends ActorSheet {
     // This creates a dynamic Shields tracker. It polls for the value of the structure system and security department. 
     // With the total value, creates a new div for each and places it under a child called "bar-shields-renderer".
     function shieldsTrackUpdate() {
-
       const localizedValues = {
         "advancedshields": game.i18n.localize('sta.actor.starship.talents.advancedshields')
       };

--- a/src/module/actors/sheets/starship-sheet2e.js
+++ b/src/module/actors/sheets/starship-sheet2e.js
@@ -29,7 +29,7 @@ export class STAStarshipSheet2e extends ActorSheet {
   get template() {
     let versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
-    if (!foundry.utils.isNewerVersion(versionInfo,"0.8.-1")) return "systems/sta/templates/actors/starship-sheet-legacy.hbs";
+    if (!foundry.utils.isNewerVersion(versionInfo, "0.8.-1")) return "systems/sta/templates/actors/starship-sheet-legacy.hbs";
     return `systems/sta/templates/actors/starship-sheet2e.hbs`;
   }
 
@@ -106,7 +106,6 @@ export class STAStarshipSheet2e extends ActorSheet {
     // This creates a dynamic Shields tracker. It polls for the value of the structure system and security department. 
     // With the total value, creates a new div for each and places it under a child called "bar-shields-renderer".
     function shieldsTrackUpdate() {
-
       const localizedValues = {
         "advancedshields": game.i18n.localize('sta.actor.starship.talents.advancedshields'),
         "polarizedhullplating": game.i18n.localize('sta.actor.starship.talents.polarizedhullplating')
@@ -138,11 +137,11 @@ export class STAStarshipSheet2e extends ActorSheet {
     // This creates a dynamic Power tracker. It polls for the value of the engines system. 
     // With the value, creates a new div for each and places it under a child called "bar-power-renderer".
     function powerTrackUpdate() {
-//      powerTrackMax = parseInt(html.find('#engines')[0].value);
+      // powerTrackMax = parseInt(html.find('#engines')[0].value);
       powerTrackMax = 0;
-//      if (html.find('[data-talent-name*="Secondary Reactors"]').length > 0) {
-//        powerTrackMax += 5;
-//      }
+      // if (html.find('[data-talent-name*="Secondary Reactors"]').length > 0) {
+      //  powerTrackMax += 5;
+      // }
       // This checks that the max-power hidden field is equal to the calculated Max Power value, if not it makes it so.
       if (html.find('#max-power')[0].value != powerTrackMax) {
         html.find('#max-power')[0].value = powerTrackMax;
@@ -162,7 +161,6 @@ export class STAStarshipSheet2e extends ActorSheet {
     // This creates a dynamic Crew Support tracker. It polls for the value of the ships's scale. 
     // With the value, creates a new div for each and places it under a child called "bar-crew-renderer".
     function crewTrackUpdate() {
-
       const localizedValues = {
         "extensiveautomation": game.i18n.localize('sta.actor.starship.talents.extensiveautomation'),
         "abundantpersonnel": game.i18n.localize('sta.actor.starship.talents.abundantpersonnel'),
@@ -170,15 +168,15 @@ export class STAStarshipSheet2e extends ActorSheet {
       };
 
       crewTrackMax = parseInt(html.find('#scale')[0].value) + parseInt(html.find('#crwmod')[0].value);
-        if (html.find(`[data-talent-name*="${localizedValues.agingrelic}"]`).length > 0) {
+      if (html.find(`[data-talent-name*="${localizedValues.agingrelic}"]`).length > 0) {
         crewTrackMax += 1;
-        }
-        if (html.find(`[data-talent-name*="${localizedValues.extensiveautomation}"]`).length > 0) {
+      }
+      if (html.find(`[data-talent-name*="${localizedValues.extensiveautomation}"]`).length > 0) {
         crewTrackMax = Math.ceil(crewTrackMax/2);
-        }
-        if (html.find(`[data-talent-name*="${localizedValues.abundantpersonnel}"]`).length > 0) {
+      }
+      if (html.find(`[data-talent-name*="${localizedValues.abundantpersonnel}"]`).length > 0) {
         crewTrackMax += crewTrackMax;
-       }  
+      }
       // This checks that the max-crew hidden field is equal to the calculated Max Crew Support value, if not it makes it so.
       if (html.find('#max-crew')[0].value != crewTrackMax) {
         html.find('#max-crew')[0].value = crewTrackMax;
@@ -523,25 +521,25 @@ export class STAStarshipSheet2e extends ActorSheet {
       const shipScaleValue = Number.parseInt(html.find('#scale').attr('value'));
       let totalBreaches = 0;
 
-    html.find('.selector.system').each(function(index, value) {
-      const $systemCheckbox = $(value);
-      const $systemBreach = $systemCheckbox.siblings('.breaches');
-      const breachValue = Number.parseInt($systemBreach.attr('value'));
+      html.find('.selector.system').each(function(index, value) {
+        const $systemCheckbox = $(value);
+        const $systemBreach = $systemCheckbox.siblings('.breaches');
+        const breachValue = Number.parseInt($systemBreach.attr('value'));
 
-      totalBreaches += breachValue;
+        totalBreaches += breachValue;
 
-      const isSystemDestroyed = breachValue >= (Math.ceil(shipScaleValue / 2)) ? true : false;
+        const isSystemDestroyed = breachValue >= (Math.ceil(shipScaleValue / 2)) ? true : false;
 
-      if (breachValue > 0 && !isSystemDestroyed) {
-        $systemBreach.addClass('highlight-damaged');
-        $systemBreach.removeClass('highlight-destroyed');
-      } else if (isSystemDestroyed) {
-        $systemBreach.addClass('highlight-destroyed');
-        $systemBreach.removeClass('highlight-damaged');
-      } else {
-        $systemBreach.removeClass('highlight-damaged highlight-disabled highlight-destroyed');
-      }
-    });
+        if (breachValue > 0 && !isSystemDestroyed) {
+          $systemBreach.addClass('highlight-damaged');
+          $systemBreach.removeClass('highlight-destroyed');
+        } else if (isSystemDestroyed) {
+          $systemBreach.addClass('highlight-destroyed');
+          $systemBreach.removeClass('highlight-damaged');
+        } else {
+          $systemBreach.removeClass('highlight-damaged highlight-disabled highlight-destroyed');
+        }
+      });
 
       if (totalBreaches === (shipScaleValue + 1)) {
         sheetElement.addClass('highlight-damaged');

--- a/src/module/actors/sheets/starship-sheet2e.js
+++ b/src/module/actors/sheets/starship-sheet2e.js
@@ -29,7 +29,7 @@ export class STAStarshipSheet2e extends ActorSheet {
   get template() {
     let versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
-    if (!foundry.utils.isNewerVersion(versionInfo, "0.8.-1")) return "systems/sta/templates/actors/starship-sheet-legacy.hbs";
+    if (!foundry.utils.isNewerVersion(versionInfo, '0.8.-1')) return 'systems/sta/templates/actors/starship-sheet-legacy.hbs';
     return `systems/sta/templates/actors/starship-sheet2e.hbs`;
   }
 
@@ -107,8 +107,8 @@ export class STAStarshipSheet2e extends ActorSheet {
     // With the total value, creates a new div for each and places it under a child called "bar-shields-renderer".
     function shieldsTrackUpdate() {
       const localizedValues = {
-        "advancedshields": game.i18n.localize('sta.actor.starship.talents.advancedshields'),
-        "polarizedhullplating": game.i18n.localize('sta.actor.starship.talents.polarizedhullplating')
+        'advancedshields': game.i18n.localize('sta.actor.starship.talents.advancedshields'),
+        'polarizedhullplating': game.i18n.localize('sta.actor.starship.talents.polarizedhullplating')
       };
 
       shieldsTrackMax = parseInt(html.find('#structure')[0].value) + parseInt(html.find('#security')[0].value) + parseInt(html.find('#scale')[0].value) + parseInt(html.find('#shieldmod')[0].value);
@@ -162,9 +162,9 @@ export class STAStarshipSheet2e extends ActorSheet {
     // With the value, creates a new div for each and places it under a child called "bar-crew-renderer".
     function crewTrackUpdate() {
       const localizedValues = {
-        "extensiveautomation": game.i18n.localize('sta.actor.starship.talents.extensiveautomation'),
-        "abundantpersonnel": game.i18n.localize('sta.actor.starship.talents.abundantpersonnel'),
-        "agingrelic": game.i18n.localize('sta.actor.starship.talents.agingrelic')
+        'extensiveautomation': game.i18n.localize('sta.actor.starship.talents.extensiveautomation'),
+        'abundantpersonnel': game.i18n.localize('sta.actor.starship.talents.abundantpersonnel'),
+        'agingrelic': game.i18n.localize('sta.actor.starship.talents.agingrelic')
       };
 
       crewTrackMax = parseInt(html.find('#scale')[0].value) + parseInt(html.find('#crwmod')[0].value);
@@ -508,7 +508,7 @@ export class STAStarshipSheet2e extends ActorSheet {
       if (parseInt(html.find('#weapons')[0].value) > 12) weaponValue = 4;
 
       let scaleDamage = 0;
-      if (value.dataset.itemIncludescale == "energy") scaleDamage = parseInt(html.find('#scale')[0].value);
+      if (value.dataset.itemIncludescale == 'energy') scaleDamage = parseInt(html.find('#scale')[0].value);
 
       const attackDamageValue = weaponDamage + weaponValue + scaleDamage;
       value.getElementsByClassName('damage')[0].innerText = attackDamageValue;

--- a/src/module/actors/sheets/starship-sheet2e.js
+++ b/src/module/actors/sheets/starship-sheet2e.js
@@ -3,12 +3,15 @@ import {
 } from '../actor.js';
 
 export class STAStarshipSheet2e extends ActorSheet {
+  constructor(object, options={}) {
+    super(object, options);
 
-  /**
-   * An actively open dialog that should be closed before a new one is opened.
-   * @type {Dialog}
-   */
-  activeDialog;
+    /**
+     * An actively open dialog that should be closed before a new one is opened.
+     * @type {Dialog}
+     */
+    this.activeDialog = null;
+  }
 
   /** @override */
   static get defaultOptions() {

--- a/src/module/actors/sheets/starship-sheet2e.js
+++ b/src/module/actors/sheets/starship-sheet2e.js
@@ -116,7 +116,7 @@ export class STAStarshipSheet2e extends ActorSheet {
         shieldsTrackMax += 5;
       }
       if (html.find(`[data-talent-name*="${localizedValues.polarizedhullplating}"]`).length > 0) {
-        shieldsTrackMax = parseInt(html.find('#structure')[0].value) + parseInt(html.find('#shieldmod')[0].value)
+        shieldsTrackMax = parseInt(html.find('#structure')[0].value) + parseInt(html.find('#shieldmod')[0].value);
       }
       // This checks that the max-shields hidden field is equal to the calculated Max Shields value, if not it makes it so.
       if (html.find('#max-shields')[0].value != shieldsTrackMax) {

--- a/src/module/actors/sheets/starship-sheet2e.js
+++ b/src/module/actors/sheets/starship-sheet2e.js
@@ -27,7 +27,7 @@ export class STAStarshipSheet2e extends ActorSheet {
   // If the player is not a GM and has limited permissions - send them to the limited sheet, otherwise, continue as usual.
   /** @override */
   get template() {
-    let versionInfo = game.world.coreVersion;
+    const versionInfo = game.world.coreVersion;
     if ( !game.user.isGM && this.actor.limited) return 'systems/sta/templates/actors/limited-sheet.hbs';
     if (!foundry.utils.isNewerVersion(versionInfo, '0.8.-1')) return 'systems/sta/templates/actors/starship-sheet-legacy.hbs';
     return `systems/sta/templates/actors/starship-sheet2e.hbs`;
@@ -89,7 +89,7 @@ export class STAStarshipSheet2e extends ActorSheet {
     super.activateListeners(html);
     
     // Allows checking version easily 
-    let versionInfo = game.world.coreVersion; 
+    const versionInfo = game.world.coreVersion;
 
     // Opens the class STASharedActorFunctions for access at various stages.
     const staActor = new STASharedActorFunctions();
@@ -515,8 +515,8 @@ export class STAStarshipSheet2e extends ActorSheet {
     });
 
     Hooks.on('renderSTAStarshipSheet2e', (app, html, data) => {
-      let sheetId = app.id;
-      let sheetElement = $(`#${sheetId} .main`);
+      const sheetId = app.id;
+      const sheetElement = $(`#${sheetId} .main`);
 
       const shipScaleValue = Number.parseInt(html.find('#scale').attr('value'));
       let totalBreaches = 0;

--- a/src/module/apps/roll-dialog.js
+++ b/src/module/apps/roll-dialog.js
@@ -3,7 +3,7 @@ export class STARollDialog {
     let html = '';
     if (isAttribute) {
       // Grab the RollDialog HTML file/
-      if (selectedAttribute === "STARoller") {
+      if (selectedAttribute === 'STARoller') {
 		  html = await renderTemplate('systems/sta/templates/apps/STARoller-attribute.hbs', {'defaultValue': defaultValue});
 	  } else {
         html = await renderTemplate('systems/sta/templates/apps/dicepool-attribute.hbs', {'defaultValue': defaultValue});

--- a/src/module/apps/roll-dialog.js
+++ b/src/module/apps/roll-dialog.js
@@ -5,9 +5,8 @@ export class STARollDialog {
       // Grab the RollDialog HTML file/
       if (selectedAttribute === "STARoller") {
 		  html = await renderTemplate('systems/sta/templates/apps/STARoller-attribute.hbs', {'defaultValue': defaultValue});
-	  }
-      else {
-          html = await renderTemplate('systems/sta/templates/apps/dicepool-attribute.hbs', {'defaultValue': defaultValue});
+	  } else {
+        html = await renderTemplate('systems/sta/templates/apps/dicepool-attribute.hbs', {'defaultValue': defaultValue});
 	  }
     } else {
       html = await renderTemplate('systems/sta/templates/apps/dicepool-challenge.hbs', {'defaultValue': defaultValue});

--- a/src/module/apps/tracker.js
+++ b/src/module/apps/tracker.js
@@ -4,7 +4,6 @@
     If code changes are being here made, temporarily switching to ES2022 within
     the eslint.config.mjs on your local machine is advised to catch mistakes.
  */
-/* eslint-disable */
 
 export class STATracker extends Application {
   constructor(options = {}) {

--- a/src/module/apps/tracker.js
+++ b/src/module/apps/tracker.js
@@ -65,7 +65,7 @@ export class STATracker extends Application {
     }
 
     // Whether the A/V is collapsed or not.  Not exactly "hidden" as the name implies.
-    const dockHidden =  game.webrtc.settings.client.hideDock;
+    const dockHidden = game.webrtc.settings.client.hideDock;
     if (dockHidden) {
       tracker.classList.add(CSS_CLASSES.DOCK_COLLAPSE);
     } else {
@@ -285,72 +285,72 @@ export class STATracker extends Application {
 
   static async DoUpdateResource(resource, newValue) {
     if (!STATracker.UserHasPermissionFor(resource)) {
-        ui.notifications.error(game.i18n.localize(`sta.notifications.${resource}invalidpermissions`));
-        return;
+      ui.notifications.error(game.i18n.localize(`sta.notifications.${resource}invalidpermissions`));
+      return;
     } else if (newValue < 0) {
-        ui.notifications.warn(game.i18n.localize(`sta.notifications.${resource}min`));
-        STATracker.UpdateTracker();
-        return;
+      ui.notifications.warn(game.i18n.localize(`sta.notifications.${resource}min`));
+      STATracker.UpdateTracker();
+      return;
     } else if (newValue > STATracker.LimitOf(resource)) {
-        ui.notifications.warn(game.i18n.localize(`sta.notifications.${resource}max`) + STATracker.LimitOf(resource) + '!');
-        STATracker.UpdateTracker();
-        return;
+      ui.notifications.warn(game.i18n.localize(`sta.notifications.${resource}max`) + STATracker.LimitOf(resource) + '!');
+      STATracker.UpdateTracker();
+      return;
     }
 
     let currentValue = STATracker.ValueOf(resource);
     
     if (newValue !== currentValue) {
-        if (STATracker.UserCanWriteSettings()) {
-            await game.settings.set('sta', resource, newValue);
-            STATracker.SendUpdateMessage(STATracker.MessageType.UpdateResource);
-            STATracker.UpdateTracker();
-        } else {
-            STATracker.SendUpdateMessage(STATracker.MessageType.SetResource, resource, newValue);
-        }
+      if (STATracker.UserCanWriteSettings()) {
+        await game.settings.set('sta', resource, newValue);
+        STATracker.SendUpdateMessage(STATracker.MessageType.UpdateResource);
+        STATracker.UpdateTracker();
+      } else {
+        STATracker.SendUpdateMessage(STATracker.MessageType.SetResource, resource, newValue);
+      }
 
-        // Accumulate changes for momentum or threat
-        let resourceName = resource === STATracker.Resource.Momentum ? "momentum" : "threat";
-        let diff = newValue - currentValue;
-        STATracker.accumulatedChanges[resourceName] += diff;
+      // Accumulate changes for momentum or threat
+      let resourceName = resource === STATracker.Resource.Momentum ? "momentum" : "threat";
+      let diff = newValue - currentValue;
+      STATracker.accumulatedChanges[resourceName] += diff;
 
-        // Clear any previous timeout and reset it
-        if (STATracker.chatMessageTimeout) {
-            clearTimeout(STATracker.chatMessageTimeout);
-        }
+      // Clear any previous timeout and reset it
+      if (STATracker.chatMessageTimeout) {
+        clearTimeout(STATracker.chatMessageTimeout);
+      }
 
-        // Set a new timeout to send the chat message after 1 second of inactivity
-        STATracker.chatMessageTimeout = setTimeout(() => {
-            let momentumDiff = STATracker.accumulatedChanges.momentum;
-            let threatDiff = STATracker.accumulatedChanges.threat;
-            let chatMessage = '';
+      // Set a new timeout to send the chat message after 1 second of inactivity
+      STATracker.chatMessageTimeout = setTimeout(() => {
+        let momentumDiff = STATracker.accumulatedChanges.momentum;
+        let threatDiff = STATracker.accumulatedChanges.threat;
+        let chatMessage = '';
 
-            // Construct the chat message based on the accumulated changes
+        // Construct the chat message based on the accumulated changes
         if (momentumDiff !== 0) {
-            let momentumAction = momentumDiff > 0 ? 
-                game.i18n.format("sta.apps.addmomentum", {0: momentumDiff}) : 
-                game.i18n.format("sta.apps.removemomentum", {0: Math.abs(momentumDiff)});
-            chatMessage += `${game.user.name} ${momentumAction}. `;
+          let momentumAction = momentumDiff > 0 ?
+            game.i18n.format("sta.apps.addmomentum", {0: momentumDiff}) :
+            game.i18n.format("sta.apps.removemomentum", {0: Math.abs(momentumDiff)});
+          chatMessage += `${game.user.name} ${momentumAction}. `;
         }
         if (threatDiff !== 0) {
-            let threatAction = threatDiff > 0 ? 
-                game.i18n.format("sta.apps.addthreat", {0: threatDiff}) : 
-                game.i18n.format("sta.apps.removethreat", {0: Math.abs(threatDiff)});
-            chatMessage += `${game.user.name} ${threatAction}.`;
+          let threatAction = threatDiff > 0 ?
+            game.i18n.format("sta.apps.addthreat", {0: threatDiff}) :
+            game.i18n.format("sta.apps.removethreat", {0: Math.abs(threatDiff)});
+          chatMessage += `${game.user.name} ${threatAction}.`;
         }
 
-            // Send the chat message
-            if (chatMessage && game.settings.get('sta', 'sendMomemtumThreatToChat')) {
-                ChatMessage.create({
-                    speaker: { alias: "STA" },
-                    content: chatMessage
-                });
-            }
+        // Send the chat message
+        if (chatMessage && game.settings.get('sta', 'sendMomemtumThreatToChat')) {
+          ChatMessage.create({
+            speaker: { alias: "STA" },
+            content: chatMessage
+          });
+        }
 
-            // Reset the accumulated changes
-            STATracker.accumulatedChanges.momentum = 0;
-            STATracker.accumulatedChanges.threat = 0;
+        // Reset the accumulated changes
+        STATracker.accumulatedChanges.momentum = 0;
+        STATracker.accumulatedChanges.threat = 0;
 
-        }, 1000);  // 1-second delay
+      }, 1000); // 1-second delay
     }
   }
 
@@ -390,7 +390,7 @@ export class STATracker extends Application {
    * 
    * @private
    */
-   static ConfigureTrackerInterface() {
+  static ConfigureTrackerInterface() {
     if (!this.UserHasPermissionFor(STATracker.Resource.Momentum)) {
       STATracker.MomentumButtons.forEach(b => b.style.display = "none");
       STATracker.MomentumInput.disabled = true;
@@ -407,7 +407,7 @@ export class STATracker extends Application {
    * 
    * @private
    */
-   static ConfigureTrackerButtonActions() {
+  static ConfigureTrackerButtonActions() {
     $('#sta-momentum-track-decrease > .fas').click((_) => STATracker.OnAdjustTracker(STATracker.Resource.Momentum, -1));
     $('#sta-momentum-track-increase > .fas').click((_) => STATracker.OnAdjustTracker(STATracker.Resource.Momentum, +1));
     $('#sta-threat-track-decrease > .fas').click((_) => STATracker.OnAdjustTracker(STATracker.Resource.Threat, -1));
@@ -419,7 +419,7 @@ export class STATracker extends Application {
    * 
    * @private
    */
-   static ConfigureTrackerInputActions() {
+  static ConfigureTrackerInputActions() {
     $('#sta-track-momentum').keydown((ev) => {
       if (ev.keyCode == 13) {
         $('#sta-track-momentum').blur();
@@ -458,7 +458,7 @@ export class STATracker extends Application {
   /**
    * @private
    */
-   static ConfigureTrackerSlideWithSidebar() {
+  static ConfigureTrackerSlideWithSidebar() {
     $('.collapse').click((_) => {
       console.log('collape clicked')
       if ($('.tracker-container:not(.tracker-collapsed)')[0]) {
@@ -482,16 +482,16 @@ export class STATracker extends Application {
    */
   static async OnSocketData(message) {
     switch (message.type) {
-      case STATracker.MessageType.SetResource:
-        if (STATracker.UserCanWriteSettings()) {
-          await game.settings.set('sta', message.resource, message.value);
-          STATracker.SendUpdateMessage(STATracker.MessageType.UpdateResource);
-          STATracker.UpdateTracker();
-        }
-        break;
-      case STATracker.MessageType.UpdateResource:
+    case STATracker.MessageType.SetResource:
+      if (STATracker.UserCanWriteSettings()) {
+        await game.settings.set('sta', message.resource, message.value);
+        STATracker.SendUpdateMessage(STATracker.MessageType.UpdateResource);
         STATracker.UpdateTracker();
-        break;
+      }
+      break;
+    case STATracker.MessageType.UpdateResource:
+      STATracker.UpdateTracker();
+      break;
     }
   }
 

--- a/src/module/apps/tracker.js
+++ b/src/module/apps/tracker.js
@@ -53,12 +53,10 @@ export class STATracker extends Application {
     if (AVSettings.DOCK_POSITIONS.RIGHT === dockPosition) {
       tracker.classList.add(CSS_CLASSES.DOCK_RIGHT);
       tracker.classList.remove(CSS_CLASSES.DOCK_BOTTOM);
-    }
-    else if (AVSettings.DOCK_POSITIONS.BOTTOM === dockPosition) {
+    } else if (AVSettings.DOCK_POSITIONS.BOTTOM === dockPosition) {
       tracker.classList.remove(CSS_CLASSES.DOCK_RIGHT);
       tracker.classList.add(CSS_CLASSES.DOCK_BOTTOM);
-    }
-    else {
+    } else {
       tracker.classList.remove(CSS_CLASSES.DOCK_RIGHT);
       tracker.classList.remove(CSS_CLASSES.DOCK_BOTTOM);
       tracker.classList.remove(CSS_CLASSES.DOCK_COLLAPSE);
@@ -392,12 +390,12 @@ export class STATracker extends Application {
    */
   static ConfigureTrackerInterface() {
     if (!this.UserHasPermissionFor(STATracker.Resource.Momentum)) {
-      STATracker.MomentumButtons.forEach(b => b.style.display = 'none');
+      STATracker.MomentumButtons.forEach((b) => b.style.display = 'none');
       STATracker.MomentumInput.disabled = true;
     }
 
     if (!this.UserHasPermissionFor(STATracker.Resource.Threat)) {
-      STATracker.ThreatButtons.forEach(b => b.style.display = 'none');
+      STATracker.ThreatButtons.forEach((b) => b.style.display = 'none');
       STATracker.ThreatInput.disabled = true;
     }
   }
@@ -450,7 +448,7 @@ export class STATracker extends Application {
         $('#tracker-clickable-plus').addClass('hide');
         $('#tracker-clickable-minus').removeClass('hide');
         $('.tracker-container').addClass('hide').removeAttr('style');
-        $('.tracker-container').removeClass('hide').width('180px')
+        $('.tracker-container').removeClass('hide').width('180px');
       }
     });
   }
@@ -469,7 +467,7 @@ export class STATracker extends Application {
         $('#tracker-clickable-plus').addClass('tracker-collapsed');
         $('#tracker-clickable-minus').removeClass('tracker-collapsed');
         $('.tracker-container').addClass('tracker-collapsed').removeAttr('style');
-        $('.tracker-container').removeClass('tracker-collapsed').width('180px')
+        $('.tracker-container').removeClass('tracker-collapsed').width('180px');
       }
     });
   }
@@ -504,13 +502,13 @@ export class STATracker extends Application {
     STATracker.MomentumButtons.push(
       html.find('#sta-momentum-track-decrease')[0],
       html.find('#sta-momentum-track-increase')[0]
-    )
+    );
     STATracker.MomentumInput = html.find('#sta-track-momentum')[0];
 
     STATracker.ThreatButtons.push(
       html.find('#sta-threat-track-decrease')[0],
       html.find('#sta-threat-track-increase')[0]
-    )
+    );
     STATracker.ThreatInput = html.find('#sta-track-threat')[0];
 
     game.socket.on(STATracker.UPDATE_SOCKET_NAME, STATracker.OnSocketData);

--- a/src/module/apps/tracker.js
+++ b/src/module/apps/tracker.js
@@ -1,3 +1,11 @@
+/** TODO: Reformat this file so that it aligns with ES2020 constraints or update
+    the ESLint config to allow for ES2022.  Currently cannot be parsed by ES2020.
+
+    If code changes are being here made, temporarily switching to ES2022 within
+    the eslint.config.mjs on your local machine is advised to catch mistakes.
+ */
+/* eslint-disable */
+
 export class STATracker extends Application {
   constructor(options = {}) {
     super(options);
@@ -156,7 +164,7 @@ export class STATracker extends Application {
       this.resource = resource;
       this.value = value;
     }
-  }
+  };
 
   /**
    * The default settings of this application.
@@ -164,6 +172,8 @@ export class STATracker extends Application {
    * @public
    * @readonly
    * @property {object}
+   *
+   * @return {ApplicationOptions}
    */
   static get defaultOptions() {
     const options = super.defaultOptions;
@@ -214,7 +224,7 @@ export class STATracker extends Application {
    * 
    * @private
    * @param {STATracker.Resource} resource The resource to query the limit of.
-   * @returns {6|99999999}
+   * @return {6|99999999}
    */
   static LimitOf(resource) {
     return resource == STATracker.Resource.Momentum ? game.settings.get('sta', 'maxNumberOfMomentum') : 99999999;
@@ -225,7 +235,7 @@ export class STATracker extends Application {
    * 
    * @private
    * @param {STATracker.Resource} resource The resource to query the value of.
-   * @returns {number} The current value of the given resource
+   * @return {number} The current value of the given resource
    */
   static ValueOf(resource) {
     return game.settings.get('sta', resource);
@@ -249,7 +259,7 @@ export class STATracker extends Application {
    * Check if the user has the permission to modify the given resource.
    * 
    * @param {STATracker.Resource} resource The resource to check the current user's permissions for.
-   * @returns {true|false} true iff. the current user is allowed to modify the given resource, false otherwise.
+   * @return {true|false} true iff. the current user is allowed to modify the given resource, false otherwise.
    */
   static UserHasPermissionFor(resource) {
     const requiredLevel = game.settings.get('sta', `${resource}PermissionLevel`);
@@ -259,7 +269,7 @@ export class STATracker extends Application {
   /**
    * Check if the user has permission to write settings.
    * 
-   * @returns {true|false} true iff. the current user is allowed to write settings.
+   * @return {true|false} true iff. the current user is allowed to write settings.
    */
   static UserCanWriteSettings() {
     return game.permissions.SETTINGS_MODIFY.includes(game.user.role);
@@ -273,7 +283,7 @@ export class STATracker extends Application {
    * @param {number} value The value to set for the given resource.
    */
 
-// Store the accumulated changes and a timer
+  // Store the accumulated changes and a timer
   static accumulatedChanges = {
     momentum: 0,
     threat: 0
@@ -339,7 +349,7 @@ export class STATracker extends Application {
         // Send the chat message
         if (chatMessage && game.settings.get('sta', 'sendMomemtumThreatToChat')) {
           ChatMessage.create({
-            speaker: { alias: 'STA' },
+            speaker: {alias: 'STA'},
             content: chatMessage
           });
         }
@@ -347,7 +357,6 @@ export class STATracker extends Application {
         // Reset the accumulated changes
         STATracker.accumulatedChanges.momentum = 0;
         STATracker.accumulatedChanges.threat = 0;
-
       }, 1000); // 1-second delay
     }
   }
@@ -458,7 +467,6 @@ export class STATracker extends Application {
    */
   static ConfigureTrackerSlideWithSidebar() {
     $('.collapse').click((_) => {
-      console.log('collape clicked')
       if ($('.tracker-container:not(.tracker-collapsed)')[0]) {
         $('#tracker-clickable-minus').addClass('tracker-collapsed');
         $('#tracker-clickable-plus').removeClass('tracker-collapsed');

--- a/src/module/apps/tracker.js
+++ b/src/module/apps/tracker.js
@@ -254,7 +254,7 @@ export class STATracker extends Application {
    * @returns {true|false} true iff. the current user is allowed to modify the given resource, false otherwise.
    */
   static UserHasPermissionFor(resource) {
-    let requiredLevel = game.settings.get('sta', `${resource}PermissionLevel`);
+    const requiredLevel = game.settings.get('sta', `${resource}PermissionLevel`);
     return game.user.hasRole(requiredLevel);
   }
 
@@ -297,7 +297,7 @@ export class STATracker extends Application {
       return;
     }
 
-    let currentValue = STATracker.ValueOf(resource);
+    const currentValue = STATracker.ValueOf(resource);
     
     if (newValue !== currentValue) {
       if (STATracker.UserCanWriteSettings()) {
@@ -309,8 +309,8 @@ export class STATracker extends Application {
       }
 
       // Accumulate changes for momentum or threat
-      let resourceName = resource === STATracker.Resource.Momentum ? 'momentum' : 'threat';
-      let diff = newValue - currentValue;
+      const resourceName = resource === STATracker.Resource.Momentum ? 'momentum' : 'threat';
+      const diff = newValue - currentValue;
       STATracker.accumulatedChanges[resourceName] += diff;
 
       // Clear any previous timeout and reset it
@@ -320,19 +320,19 @@ export class STATracker extends Application {
 
       // Set a new timeout to send the chat message after 1 second of inactivity
       STATracker.chatMessageTimeout = setTimeout(() => {
-        let momentumDiff = STATracker.accumulatedChanges.momentum;
-        let threatDiff = STATracker.accumulatedChanges.threat;
+        const momentumDiff = STATracker.accumulatedChanges.momentum;
+        const threatDiff = STATracker.accumulatedChanges.threat;
         let chatMessage = '';
 
         // Construct the chat message based on the accumulated changes
         if (momentumDiff !== 0) {
-          let momentumAction = momentumDiff > 0 ?
+          const momentumAction = momentumDiff > 0 ?
             game.i18n.format('sta.apps.addmomentum', {0: momentumDiff}) :
             game.i18n.format('sta.apps.removemomentum', {0: Math.abs(momentumDiff)});
           chatMessage += `${game.user.name} ${momentumAction}. `;
         }
         if (threatDiff !== 0) {
-          let threatAction = threatDiff > 0 ?
+          const threatAction = threatDiff > 0 ?
             game.i18n.format('sta.apps.addthreat', {0: threatDiff}) :
             game.i18n.format('sta.apps.removethreat', {0: Math.abs(threatDiff)});
           chatMessage += `${game.user.name} ${threatAction}.`;
@@ -371,7 +371,7 @@ export class STATracker extends Application {
    * @param {STATracker.Resource} resource The resource to handle the event for.
    */
   static OnInputTracker(resource) {
-    let inputValue = Number.parseInt(document.getElementById(`sta-track-${resource}`).value);
+    const inputValue = Number.parseInt(document.getElementById(`sta-track-${resource}`).value);
     STATracker.DoUpdateResource(resource, inputValue);
   }
 

--- a/src/module/apps/tracker.js
+++ b/src/module/apps/tracker.js
@@ -80,7 +80,7 @@ export class STATracker extends Application {
    * @readonly
    * @constant {string}
    */
-  static UPDATE_SOCKET_NAME = "system.sta";
+  static UPDATE_SOCKET_NAME = 'system.sta';
 
   /**
    * An enumeration to identify different messages transmitted on the tracker update socket.
@@ -91,9 +91,9 @@ export class STATracker extends Application {
    */
   static MessageType = {
     /** Signal that a resource shall be set to the specified value */
-    SetResource: "set-resource",
+    SetResource: 'set-resource',
     /** Signal that the resource tracker shall be re-rendered to reflect to current resource values */
-    UpdateResource: "update-resource",
+    UpdateResource: 'update-resource',
   };
 
   /**
@@ -108,9 +108,9 @@ export class STATracker extends Application {
    */
   static Resource = {
     /** The momentum resource */
-    Momentum: "momentum",
+    Momentum: 'momentum',
     /** The threat resource */
-    Threat: "threat",
+    Threat: 'threat',
   };
 
   /**
@@ -230,7 +230,7 @@ export class STATracker extends Application {
    * @returns {number} The current value of the given resource
    */
   static ValueOf(resource) {
-    return game.settings.get("sta", resource);
+    return game.settings.get('sta', resource);
   }
 
   /**
@@ -254,7 +254,7 @@ export class STATracker extends Application {
    * @returns {true|false} true iff. the current user is allowed to modify the given resource, false otherwise.
    */
   static UserHasPermissionFor(resource) {
-    let requiredLevel = game.settings.get("sta", `${resource}PermissionLevel`);
+    let requiredLevel = game.settings.get('sta', `${resource}PermissionLevel`);
     return game.user.hasRole(requiredLevel);
   }
 
@@ -309,7 +309,7 @@ export class STATracker extends Application {
       }
 
       // Accumulate changes for momentum or threat
-      let resourceName = resource === STATracker.Resource.Momentum ? "momentum" : "threat";
+      let resourceName = resource === STATracker.Resource.Momentum ? 'momentum' : 'threat';
       let diff = newValue - currentValue;
       STATracker.accumulatedChanges[resourceName] += diff;
 
@@ -327,21 +327,21 @@ export class STATracker extends Application {
         // Construct the chat message based on the accumulated changes
         if (momentumDiff !== 0) {
           let momentumAction = momentumDiff > 0 ?
-            game.i18n.format("sta.apps.addmomentum", {0: momentumDiff}) :
-            game.i18n.format("sta.apps.removemomentum", {0: Math.abs(momentumDiff)});
+            game.i18n.format('sta.apps.addmomentum', {0: momentumDiff}) :
+            game.i18n.format('sta.apps.removemomentum', {0: Math.abs(momentumDiff)});
           chatMessage += `${game.user.name} ${momentumAction}. `;
         }
         if (threatDiff !== 0) {
           let threatAction = threatDiff > 0 ?
-            game.i18n.format("sta.apps.addthreat", {0: threatDiff}) :
-            game.i18n.format("sta.apps.removethreat", {0: Math.abs(threatDiff)});
+            game.i18n.format('sta.apps.addthreat', {0: threatDiff}) :
+            game.i18n.format('sta.apps.removethreat', {0: Math.abs(threatDiff)});
           chatMessage += `${game.user.name} ${threatAction}.`;
         }
 
         // Send the chat message
         if (chatMessage && game.settings.get('sta', 'sendMomemtumThreatToChat')) {
           ChatMessage.create({
-            speaker: { alias: "STA" },
+            speaker: { alias: 'STA' },
             content: chatMessage
           });
         }
@@ -392,12 +392,12 @@ export class STATracker extends Application {
    */
   static ConfigureTrackerInterface() {
     if (!this.UserHasPermissionFor(STATracker.Resource.Momentum)) {
-      STATracker.MomentumButtons.forEach(b => b.style.display = "none");
+      STATracker.MomentumButtons.forEach(b => b.style.display = 'none');
       STATracker.MomentumInput.disabled = true;
     }
 
     if (!this.UserHasPermissionFor(STATracker.Resource.Threat)) {
-      STATracker.ThreatButtons.forEach(b => b.style.display = "none");
+      STATracker.ThreatButtons.forEach(b => b.style.display = 'none');
       STATracker.ThreatInput.disabled = true;
     }
   }

--- a/src/module/dice/STARoller.js
+++ b/src/module/dice/STARoller.js
@@ -293,6 +293,6 @@ export class STARoller {
   }
 }
 Hooks.on('renderSceneControls', (controls, html) => {
-  console.log('STARoller here', html);
+  /* eslint-disable-next-line new-cap */
   STARoller.Init(controls, html);
 });

--- a/src/module/dice/STARoller.js
+++ b/src/module/dice/STARoller.js
@@ -206,10 +206,10 @@ export class STARoller {
     
             const token = canvas.tokens.controlled[0];
             if (!token || (token.actor.type !== 'starship' && token.actor.type !== 'smallcraft')) {
-              selectedSystemLabel = "STARoller";
+              selectedSystemLabel = 'STARoller';
               selectedSystemValue = parseInt(html.find('#systemValue').val());
 
-              selectedDepartmentLabel = "STARoller";
+              selectedDepartmentLabel = 'STARoller';
               selectedDepartmentValue = parseInt(html.find('#departmentValue').val());
 
               speakerstarship = {

--- a/src/module/dice/STARoller.js
+++ b/src/module/dice/STARoller.js
@@ -65,9 +65,9 @@ export class STARoller {
     });
   }
   static async rollTaskRoll(event) {
-    let selectedAttribute = 'STARoller';
-    let selectedDiscipline = 'STARoller';
-    let defaultValue = 2;
+    const selectedAttribute = 'STARoller';
+    const selectedDiscipline = 'STARoller';
+    const defaultValue = 2;
     const speaker = {
       type: 'sidebar',
     };
@@ -93,8 +93,8 @@ export class STARoller {
 
 
   static async rollChallengeRoll(event) {
-    let weaponName = 'STARoller';
-    let defaultValue = 2;
+    const weaponName = 'STARoller';
+    const defaultValue = 2;
 
     event.preventDefault();
     // This creates a dialog to gather details regarding the roll and waits for a response
@@ -109,7 +109,7 @@ export class STARoller {
 
 
   static async rollnpcssroll(event) {
-    let dialogContent = `
+    const dialogContent = `
     <form>
       <h3>${game.i18n.localize('sta.roll.npccrew')}</h3>
       <div class="form-group">
@@ -159,14 +159,14 @@ export class STARoller {
           label: `${game.i18n.localize('sta.apps.rolldice')}`,
           callback: (html) => {
             // Get selected system and department
-            let selectedSystem = html.find('.selector.system:checked').val();
+            const selectedSystem = html.find('.selector.system:checked').val();
             let selectedSystemLabel = html.find(`#${selectedSystem}-selector`).siblings('.original-system-label').val();
             if (selectedSystemLabel) {
               selectedSystemLabel = selectedSystemLabel.substring(26);
             }
             let selectedSystemValue = html.find(`#${selectedSystem}`).text();
-            
-            let selectedDepartment = html.find('.selector.department:checked').val();
+
+            const selectedDepartment = html.find('.selector.department:checked').val();
             let selectedDepartmentLabel = html.find(`#${selectedDepartment}-selector`).siblings('.original-department-label').val();
             if (selectedDepartmentLabel) {
               selectedDepartmentLabel = selectedDepartmentLabel.substring(30);
@@ -175,7 +175,8 @@ export class STARoller {
     
             const numDice = parseInt(html.find('#numDice').val());
             const skillLevel = html.find('input[name="skillLevel"]:checked').val();
-            let attributes, departments;
+            let attributes;
+            let departments;
             switch (skillLevel) {
             case 'basic':
               attributes = 8;
@@ -237,14 +238,14 @@ export class STARoller {
     
         // Fallback to input box in case no token is selected
         if (!token || (token.actor.type !== 'starship' && token.actor.type !== 'smallcraft')) {
-          let systemsHtml = `
+          const systemsHtml = `
             <div>
               <input type="number" id="systemValue" name="systemValue" min="0" max="20" value="7">
             </div>
             `;
           html.find('#shipSystems').html(systemsHtml);
-    
-          let departmentsHtml = `
+
+          const departmentsHtml = `
             <div>
               <input type="number" id="departmentValue" name="departmentValue" min="0" max="10" value="2">
             </div>
@@ -258,8 +259,8 @@ export class STARoller {
     
         // Populate ship systems
         let systemsHtml = '';
-        for (let [key, system] of Object.entries(actor.system.systems)) {
-          let systemLabel = game.i18n.localize(system.label);
+        for (const [key, system] of Object.entries(actor.system.systems)) {
+          const systemLabel = game.i18n.localize(system.label);
     
           systemsHtml += `
           <div>
@@ -274,8 +275,8 @@ export class STARoller {
     
         // Populate ship departments
         let departmentsHtml = '';
-        for (let [key, department] of Object.entries(actor.system.departments)) {
-          let departmentLabel = game.i18n.localize(department.label);
+        for (const [key, department] of Object.entries(actor.system.departments)) {
+          const departmentLabel = game.i18n.localize(department.label);
     
           departmentsHtml += `
           <div>

--- a/src/module/dice/STARoller.js
+++ b/src/module/dice/STARoller.js
@@ -63,11 +63,8 @@ export class STARoller {
     npcssrollbtn.on('click', (ev) => {
       this.rollnpcssroll(ev);
     });
-
   }
- 
   static async rollTaskRoll(event) {
-
     let selectedAttribute = 'STARoller';
     let selectedDiscipline = 'STARoller';
     let defaultValue = 2;
@@ -95,8 +92,7 @@ export class STARoller {
   }
 
 
-  static async rollChallengeRoll (event) {
-
+  static async rollChallengeRoll(event) {
     let weaponName = 'STARoller';
     let defaultValue = 2;
 
@@ -112,190 +108,187 @@ export class STARoller {
   }
 
 
-static async rollnpcssroll(event) {
+  static async rollnpcssroll(event) {
+    let dialogContent = `
+    <form>
+      <h3>${game.i18n.localize('sta.roll.npccrew')}</h3>
+      <div class="form-group">
+      <label><input type="radio" name="skillLevel" value="basic" checked> ${game.i18n.localize('sta.roll.npccrewbasic')}</label><br>
+        <label><input type="radio" name="skillLevel" value="proficient"> ${game.i18n.localize('sta.roll.npccrewproficient')}</label><br>
+        <label><input type="radio" name="skillLevel" value="talented"> ${game.i18n.localize('sta.roll.npccrewtalented')}</label><br>
+        <label><input type="radio" name="skillLevel" value="exceptional"> ${game.i18n.localize('sta.roll.npccrewexceptional')}</label>
+      </div>
+      <div class="form-group">
+        <label>${game.i18n.localize('sta.apps.dicepoolwindow')}: <span id="diceValue">2</span></label>
+        <input type="range" id="numDice" name="numDice" min="1" max="5" value="2" oninput="document.getElementById('diceValue').textContent = this.value">
+      </div>
+      <h3>${game.i18n.localize('sta.roll.npcship')}</h3>
+      <div class="form-group">
+        <label>${game.i18n.localize('sta.roll.shipassisting')}<input type="checkbox" id="shipAssist" name="shipAssist"></label>
+      </div>  
+      <div class="form-group">
+        <label>${game.i18n.localize('sta.apps.dicepoolwindow')}: <span id="shipDiceValue">1</span></label>
+        <input type="range" id="shipNumDice" name="shipNumDice" min="1" max="3" value="1" oninput="document.getElementById('shipDiceValue').textContent = this.value">
+      </div>
+      <div class="form-group">
+        <table>
+          <tr>
+            <td>
+              <h3>${game.i18n.localize('sta.actor.starship.system.name')}</h3>
+              <div id="shipSystems"></div>
+            </td>
+            <td>
+              <h3>${game.i18n.localize('sta.actor.starship.department.name')}</h3>
+              <div id="shipDepartments"></div>
+            </td>
+          </tr>
+        </table>
+      </div>
+      <div class="form-group">
+        <label>${game.i18n.localize('sta.roll.complicationroller')}: <span id="complicationValue">1</span></label>
+        <input type="range" id="complication" name="complication" min="1" max="5" value="1" oninput="document.getElementById('complicationValue').textContent = this.value">
+      </div>
+    </form>`;
 
-let dialogContent = `
-<form>
-  <h3>${game.i18n.localize('sta.roll.npccrew')}</h3>
-  <div class="form-group">
-	<label><input type="radio" name="skillLevel" value="basic" checked> ${game.i18n.localize('sta.roll.npccrewbasic')}</label><br>
-    <label><input type="radio" name="skillLevel" value="proficient"> ${game.i18n.localize('sta.roll.npccrewproficient')}</label><br>
-    <label><input type="radio" name="skillLevel" value="talented"> ${game.i18n.localize('sta.roll.npccrewtalented')}</label><br>
-    <label><input type="radio" name="skillLevel" value="exceptional"> ${game.i18n.localize('sta.roll.npccrewexceptional')}</label>
-  </div>
-  <div class="form-group">
-    <label>${game.i18n.localize('sta.apps.dicepoolwindow')}: <span id="diceValue">2</span></label>
-    <input type="range" id="numDice" name="numDice" min="1" max="5" value="2" oninput="document.getElementById('diceValue').textContent = this.value">
-  </div>
-  <h3>${game.i18n.localize('sta.roll.npcship')}</h3>
-  <div class="form-group">
-    <label>${game.i18n.localize('sta.roll.shipassisting')}<input type="checkbox" id="shipAssist" name="shipAssist"></label>
-  </div>  
-  <div class="form-group">
-    <label>${game.i18n.localize('sta.apps.dicepoolwindow')}: <span id="shipDiceValue">1</span></label>
-    <input type="range" id="shipNumDice" name="shipNumDice" min="1" max="3" value="1" oninput="document.getElementById('shipDiceValue').textContent = this.value">
-  </div>
-  <div class="form-group">
-    <table>
-      <tr>
-        <td>
-          <h3>${game.i18n.localize('sta.actor.starship.system.name')}</h3>
-          <div id="shipSystems"></div>
-        </td>
-        <td>
-          <h3>${game.i18n.localize('sta.actor.starship.department.name')}</h3>
-          <div id="shipDepartments"></div>
-        </td>
-      </tr>
-    </table>
-  </div>
-  <div class="form-group">
-    <label>${game.i18n.localize('sta.roll.complicationroller')}: <span id="complicationValue">1</span></label>
-    <input type="range" id="complication" name="complication" min="1" max="5" value="1" oninput="document.getElementById('complicationValue').textContent = this.value">
-  </div>
-</form>
-`;
+    new Dialog({
+      title: `${game.i18n.localize('sta.roll.npcshipandcrewroll')}`,
+      content: dialogContent,
+      width: 600,
+      buttons: {
+        roll: {
+          label: `${game.i18n.localize('sta.apps.rolldice')}`,
+          callback: (html) => {
+            // Get selected system and department
+            let selectedSystem = html.find('.selector.system:checked').val();
+            let selectedSystemLabel = html.find(`#${selectedSystem}-selector`).siblings('.original-system-label').val();
+            if (selectedSystemLabel) {
+              selectedSystemLabel = selectedSystemLabel.substring(26);
+            }
+            let selectedSystemValue = html.find(`#${selectedSystem}`).text();
+            
+            let selectedDepartment = html.find('.selector.department:checked').val();
+            let selectedDepartmentLabel = html.find(`#${selectedDepartment}-selector`).siblings('.original-department-label').val();
+            if (selectedDepartmentLabel) {
+              selectedDepartmentLabel = selectedDepartmentLabel.substring(30);
+            }
+            let selectedDepartmentValue = html.find(`#${selectedDepartment}`).text();
+    
+            const numDice = parseInt(html.find('#numDice').val());
+            const skillLevel = html.find('input[name="skillLevel"]:checked').val();
+            let attributes, departments;
+            switch (skillLevel) {
+            case 'basic':
+              attributes = 8;
+              departments = 1;
+              break;
+            case 'proficient':
+              attributes = 9;
+              departments = 2;
+              break;
+            case 'talented':
+              attributes = 10;
+              departments = 3;
+              break;
+            case 'exceptional':
+              attributes = 11;
+              departments = 4;
+              break;
+            }
+            const complicationRange = parseInt(html.find('#complication').val());
+            const shipNumDice = parseInt(html.find('#shipNumDice').val());
+    
+            const speakerNPC = {
+              type: 'npccharacter',
+            };
+            let speakerstarship = {
+              type: 'starship',
+            };
+    
+            const token = canvas.tokens.controlled[0];
+            if (!token || (token.actor.type !== 'starship' && token.actor.type !== 'smallcraft')) {
+              selectedSystemLabel = "STARoller";
+              selectedSystemValue = parseInt(html.find('#systemValue').val());
 
-new Dialog({
-  title: `${game.i18n.localize('sta.roll.npcshipandcrewroll')}`,
-  content: dialogContent,
-  width: 600,
-  buttons: {
-    roll: {
-      label: `${game.i18n.localize('sta.apps.rolldice')}`,
-      callback: (html) => {
+              selectedDepartmentLabel = "STARoller";
+              selectedDepartmentValue = parseInt(html.find('#departmentValue').val());
 
-        // Get selected system and department
-        let selectedSystem = html.find('.selector.system:checked').val();
-        let selectedSystemLabel = html.find(`#${selectedSystem}-selector`).siblings('.original-system-label').val();
-		if (selectedSystemLabel) {
-		  selectedSystemLabel = selectedSystemLabel.substring(26);
-		}
-		let selectedSystemValue = html.find(`#${selectedSystem}`).text();
-        
-        let selectedDepartment = html.find('.selector.department:checked').val();
-        let selectedDepartmentLabel = html.find(`#${selectedDepartment}-selector`).siblings('.original-department-label').val();
-		if (selectedDepartmentLabel) {
-		  selectedDepartmentLabel = selectedDepartmentLabel.substring(30);
-		}
-		let selectedDepartmentValue = html.find(`#${selectedDepartment}`).text();
-
-        const numDice = parseInt(html.find('#numDice').val());
-        const skillLevel = html.find('input[name="skillLevel"]:checked').val();
-        let attributes, departments;
-        switch(skillLevel) {
-          case 'basic':
-            attributes = 8;
-            departments = 1;
-            break;
-          case 'proficient':
-            attributes = 9;
-            departments = 2;
-            break;
-          case 'talented':
-            attributes = 10;
-            departments = 3;
-            break;
-          case 'exceptional':
-            attributes = 11;
-            departments = 4;
-            break;
+              speakerstarship = {
+                type: 'sidebar',
+              };
+            }
+    
+            const staRoll = new STARoll();
+            staRoll.performAttributeTest(numDice, true, false, false,
+              skillLevel, attributes, skillLevel,
+              departments, complicationRange, speakerNPC);
+    
+            if (html.find('#shipAssist').is(':checked')) {
+              staRoll.performAttributeTest(shipNumDice, true, false, false,
+                selectedSystemLabel, selectedSystemValue, selectedDepartmentLabel,
+                selectedDepartmentValue, complicationRange, speakerstarship);
+            }
+          }
         }
-        const complicationRange = parseInt(html.find('#complication').val());
-        const shipNumDice = parseInt(html.find('#shipNumDice').val());
+      },
 
-        const speakerNPC = {
-            type: 'npccharacter',
-        };
-        let speakerstarship = {
-            type: 'starship',
-        };
-
+      render: (html) => {
+        html.find('button').addClass('dialog-button roll default');
         const token = canvas.tokens.controlled[0];
+    
+        // Fallback to input box in case no token is selected
         if (!token || (token.actor.type !== 'starship' && token.actor.type !== 'smallcraft')) {
-        selectedSystemLabel = "STARoller";
-        selectedSystemValue = parseInt(html.find('#systemValue').val());
-
-        selectedDepartmentLabel = "STARoller";
-        selectedDepartmentValue = parseInt(html.find('#departmentValue').val());
-
-        speakerstarship = {
-            type: 'sidebar',
-        };
+          let systemsHtml = `
+            <div>
+              <input type="number" id="systemValue" name="systemValue" min="0" max="20" value="7">
+            </div>
+            `;
+          html.find('#shipSystems').html(systemsHtml);
+    
+          let departmentsHtml = `
+            <div>
+              <input type="number" id="departmentValue" name="departmentValue" min="0" max="10" value="2">
+            </div>
+            `;
+          html.find('#shipDepartments').html(departmentsHtml);
+    
+          return;
         }
-
-      const staRoll = new STARoll();
-      staRoll.performAttributeTest(numDice, true, false, false,
-        skillLevel, attributes, skillLevel,
-        departments, complicationRange, speakerNPC);
-
-      if (html.find('#shipAssist').is(':checked')) {
-      staRoll.performAttributeTest(shipNumDice, true, false, false,
-        selectedSystemLabel, selectedSystemValue, selectedDepartmentLabel,
-        selectedDepartmentValue, complicationRange, speakerstarship);
+    
+        const actor = token.actor;
+    
+        // Populate ship systems
+        let systemsHtml = '';
+        for (let [key, system] of Object.entries(actor.system.systems)) {
+          let systemLabel = game.i18n.localize(system.label);
+    
+          systemsHtml += `
+          <div>
+            <input type="radio" id="${key}-selector" name="system" class="selector system" value="${key}">
+            <label for="${key}-selector">${systemLabel}: </label>
+            <span id="${key}">${system.value}</span>
+            <input type="hidden" for="${key}-selector" class="original-system-label" value="${system.label}">
+          </div>
+          `;
         }
-      }
-    }
-  },
-
-  render: (html) => {
-    html.find('button').addClass('dialog-button roll default');
-    const token = canvas.tokens.controlled[0];
-
-    // Fallback to input box in case no token is selected
-    if (!token || (token.actor.type !== 'starship' && token.actor.type !== 'smallcraft')) {
-        let systemsHtml = `
-        <div>
-          <input type="number" id="systemValue" name="systemValue" min="0" max="20" value="7">
-        </div>
-        `;
         html.find('#shipSystems').html(systemsHtml);
-
-        let departmentsHtml = `
-        <div>
-          <input type="number" id="departmentValue" name="departmentValue" min="0" max="10" value="2">
-        </div>
-        `;
+    
+        // Populate ship departments
+        let departmentsHtml = '';
+        for (let [key, department] of Object.entries(actor.system.departments)) {
+          let departmentLabel = game.i18n.localize(department.label);
+    
+          departmentsHtml += `
+          <div>
+            <input type="radio" id="${key}-selector" name="department" class="selector department" value="${key}">
+            <label for="${key}-selector">${departmentLabel}: </label>
+            <span id="${key}">${department.value}</span>
+            <input type="hidden" for="${key}-selector" class="original-department-label" value="${department.label}">
+          </div>
+          `;
+        }
         html.find('#shipDepartments').html(departmentsHtml);
-
-    return;
-    }
-
-    const actor = token.actor;
-
-    // Populate ship systems
-    let systemsHtml = '';
-    for (let [key, system] of Object.entries(actor.system.systems)) {
-      let systemLabel = game.i18n.localize(system.label);
-
-      systemsHtml += `
-      <div>
-        <input type="radio" id="${key}-selector" name="system" class="selector system" value="${key}">
-        <label for="${key}-selector">${systemLabel}: </label>
-        <span id="${key}">${system.value}</span>
-        <input type="hidden" for="${key}-selector" class="original-system-label" value="${system.label}">
-      </div>
-      `;
-    }
-    html.find('#shipSystems').html(systemsHtml);
-
-    // Populate ship departments
-    let departmentsHtml = '';
-    for (let [key, department] of Object.entries(actor.system.departments)) {
-      let departmentLabel = game.i18n.localize(department.label);
-
-      departmentsHtml += `
-      <div>
-        <input type="radio" id="${key}-selector" name="department" class="selector department" value="${key}">
-        <label for="${key}-selector">${departmentLabel}: </label>
-        <span id="${key}">${department.value}</span>
-        <input type="hidden" for="${key}-selector" class="original-department-label" value="${department.label}">
-      </div>
-      `;
-    }
-    html.find('#shipDepartments').html(departmentsHtml);
-  }
-}).render(true);
+      }
+    }).render(true);
   }
 }
 Hooks.on('renderSceneControls', (controls, html) => {

--- a/src/module/dice/dice-so-nice.js
+++ b/src/module/dice/dice-so-nice.js
@@ -33,7 +33,7 @@ export function register_dsn_ufp_themes(dice3d) {
       'name': 'sta-ufp-red',
       'outline': 'none'
     }
-  ].forEach(colorset => dice3d.addColorset(colorset))
+  ].forEach((colorset) => dice3d.addColorset(colorset));
 
   dice3d.addSystem({id: 'sta-black', name: 'Star Trek Adventures UFP (Black)'}, 'preferred');
   dice3d.addDicePreset({

--- a/src/module/dice/dice-so-nice.js
+++ b/src/module/dice/dice-so-nice.js
@@ -1,4 +1,4 @@
-export function register_dsn_ufp_themes(dice3d) {
+export function registerDsnUfpThemes(dice3d) {
   [
     {
       'background': '#00a3d1',

--- a/src/module/dice/dice-so-nice.js
+++ b/src/module/dice/dice-so-nice.js
@@ -35,7 +35,7 @@ export function register_dsn_ufp_themes(dice3d) {
     }
   ].forEach(colorset => dice3d.addColorset(colorset))
 
-  dice3d.addSystem({ id: "sta-black", name: "Star Trek Adventures UFP (Black)" }, "preferred");
+  dice3d.addSystem({id: "sta-black", name: "Star Trek Adventures UFP (Black)"}, "preferred");
   dice3d.addDicePreset({
     type: "d6",
     labels: [
@@ -58,7 +58,7 @@ export function register_dsn_ufp_themes(dice3d) {
     system: "sta-black",
   });
 
-  dice3d.addSystem({ id: "sta-white", name: "Star Trek Adventures UFP (White)" }, "default");
+  dice3d.addSystem({id: "sta-white", name: "Star Trek Adventures UFP (White)"}, "default");
   dice3d.addDicePreset({
     type: "d6",
     labels: [
@@ -80,5 +80,4 @@ export function register_dsn_ufp_themes(dice3d) {
     ],
     system: "sta-white",
   });
-
 }

--- a/src/module/dice/dice-so-nice.js
+++ b/src/module/dice/dice-so-nice.js
@@ -1,83 +1,83 @@
 export function register_dsn_ufp_themes(dice3d) {
   [
     {
-      "background": "#00a3d1",
-      "category": "Star Trek Adventures",
-      "description": game.i18n.localize('sta.dice.dsn.ufp.blue'),
-      "edge": "#006f8f",
-      "font": "FoundryVTT",
-      "foreground": "#000000",
-      "material": "plastic",
-      "name": "sta-ufp-blue",
-      "outline": "none"
+      'background': '#00a3d1',
+      'category': 'Star Trek Adventures',
+      'description': game.i18n.localize('sta.dice.dsn.ufp.blue'),
+      'edge': '#006f8f',
+      'font': 'FoundryVTT',
+      'foreground': '#000000',
+      'material': 'plastic',
+      'name': 'sta-ufp-blue',
+      'outline': 'none'
     },
     {
-      "background": "#f7b50c",
-      "category": "Star Trek Adventures",
-      "description": game.i18n.localize('sta.dice.dsn.ufp.gold'),
-      "edge": "#755400",
-      "font": "FoundryVTT",
-      "foreground": "#000000",
-      "material": "plastic",
-      "name": "sta-ufp-gold",
-      "outline": "none"
+      'background': '#f7b50c',
+      'category': 'Star Trek Adventures',
+      'description': game.i18n.localize('sta.dice.dsn.ufp.gold'),
+      'edge': '#755400',
+      'font': 'FoundryVTT',
+      'foreground': '#000000',
+      'material': 'plastic',
+      'name': 'sta-ufp-gold',
+      'outline': 'none'
     },
     {
-      "background": "#d62100",
-      "category": "Star Trek Adventures",
-      "description": game.i18n.localize('sta.dice.dsn.ufp.red'),
-      "edge": "#941700",
-      "font": "FoundryVTT",
-      "foreground": "#000000",
-      "material": "plastic",
-      "name": "sta-ufp-red",
-      "outline": "none"
+      'background': '#d62100',
+      'category': 'Star Trek Adventures',
+      'description': game.i18n.localize('sta.dice.dsn.ufp.red'),
+      'edge': '#941700',
+      'font': 'FoundryVTT',
+      'foreground': '#000000',
+      'material': 'plastic',
+      'name': 'sta-ufp-red',
+      'outline': 'none'
     }
   ].forEach(colorset => dice3d.addColorset(colorset))
 
-  dice3d.addSystem({id: "sta-black", name: "Star Trek Adventures UFP (Black)"}, "preferred");
+  dice3d.addSystem({id: 'sta-black', name: 'Star Trek Adventures UFP (Black)'}, 'preferred');
   dice3d.addDicePreset({
-    type: "d6",
+    type: 'd6',
     labels: [
-      "systems/sta/assets/icons/dice-so-nice/challenge_die_one_success_black.png",
-      "systems/sta/assets/icons/dice-so-nice/challenge_die_two_successes_black.png",
-      "systems/sta/assets/icons/dice-so-nice/challenge_die_no_success_black.png",
-      "systems/sta/assets/icons/dice-so-nice/challenge_die_no_success_black.png",
-      "systems/sta/assets/icons/dice-so-nice/challenge_die_effect_black.png",
-      "systems/sta/assets/icons/dice-so-nice/challenge_die_effect_black.png",
+      'systems/sta/assets/icons/dice-so-nice/challenge_die_one_success_black.png',
+      'systems/sta/assets/icons/dice-so-nice/challenge_die_two_successes_black.png',
+      'systems/sta/assets/icons/dice-so-nice/challenge_die_no_success_black.png',
+      'systems/sta/assets/icons/dice-so-nice/challenge_die_no_success_black.png',
+      'systems/sta/assets/icons/dice-so-nice/challenge_die_effect_black.png',
+      'systems/sta/assets/icons/dice-so-nice/challenge_die_effect_black.png',
     ],
-    system: "sta-black",
+    system: 'sta-black',
   });
   dice3d.addDicePreset({
-    type: "d20",
+    type: 'd20',
     labels: [
-      "systems/sta/assets/icons/dice-so-nice/d20_critical_black.png",
-      "2", "3", "4", "5", "6", "7", "8", "9", "10",
-      "11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+      'systems/sta/assets/icons/dice-so-nice/d20_critical_black.png',
+      '2', '3', '4', '5', '6', '7', '8', '9', '10',
+      '11', '12', '13', '14', '15', '16', '17', '18', '19', '20',
     ],
-    system: "sta-black",
+    system: 'sta-black',
   });
 
-  dice3d.addSystem({id: "sta-white", name: "Star Trek Adventures UFP (White)"}, "default");
+  dice3d.addSystem({id: 'sta-white', name: 'Star Trek Adventures UFP (White)'}, 'default');
   dice3d.addDicePreset({
-    type: "d6",
+    type: 'd6',
     labels: [
-      "systems/sta/assets/icons/dice-so-nice/challenge_die_one_success_white.png",
-      "systems/sta/assets/icons/dice-so-nice/challenge_die_two_successes_white.png",
-      "systems/sta/assets/icons/dice-so-nice/challenge_die_no_success_white.png",
-      "systems/sta/assets/icons/dice-so-nice/challenge_die_no_success_white.png",
-      "systems/sta/assets/icons/dice-so-nice/challenge_die_effect_white.png",
-      "systems/sta/assets/icons/dice-so-nice/challenge_die_effect_white.png",
+      'systems/sta/assets/icons/dice-so-nice/challenge_die_one_success_white.png',
+      'systems/sta/assets/icons/dice-so-nice/challenge_die_two_successes_white.png',
+      'systems/sta/assets/icons/dice-so-nice/challenge_die_no_success_white.png',
+      'systems/sta/assets/icons/dice-so-nice/challenge_die_no_success_white.png',
+      'systems/sta/assets/icons/dice-so-nice/challenge_die_effect_white.png',
+      'systems/sta/assets/icons/dice-so-nice/challenge_die_effect_white.png',
     ],
-    system: "sta-white",
+    system: 'sta-white',
   });
   dice3d.addDicePreset({
-    type: "d20",
+    type: 'd20',
     labels: [
-      "systems/sta/assets/icons/dice-so-nice/d20_critical_white.png",
-      "2", "3", "4", "5", "6", "7", "8", "9", "10",
-      "11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+      'systems/sta/assets/icons/dice-so-nice/d20_critical_white.png',
+      '2', '3', '4', '5', '6', '7', '8', '9', '10',
+      '11', '12', '13', '14', '15', '16', '17', '18', '19', '20',
     ],
-    system: "sta-white",
+    system: 'sta-white',
   });
 }

--- a/src/module/items/item.js
+++ b/src/module/items/item.js
@@ -63,7 +63,9 @@ export class STAItem extends Item {
     // Restrict character rerolls to users that have appropriate access to that character.
     if (!(game.user.isGM || speaker.isOwner)) return;
 
-    const item = storedData ? new Item(storedData, {parent: speaker}) : speaker.items.get(card.dataset.itemId);
+    const item = storedData ?
+      new Item(storedData, {parent: speaker}) :
+      speaker.items.get(card.dataset.itemId);
     if (!item) {
       // If we coudlnt' figure out the item, this is probably a reroll, in practice.
       await staActor.rollChallengeRoll(event, 'Reroll', null, speaker);

--- a/src/module/items/smallcraftcontainer-sheet.js
+++ b/src/module/items/smallcraftcontainer-sheet.js
@@ -21,7 +21,7 @@ export class STASmallCraftContainerSheet extends ItemSheet {
       ui.notifications.warn('You do not have permission to view this item!');
       return;
     }
-    if (!foundry.utils.isNewerVersion(versionInfo, "0.8.-1")) return "systems/sta/templates/items/smallcraftcontainer-sheet-legacy.hbs";
+    if (!foundry.utils.isNewerVersion(versionInfo, '0.8.-1')) return 'systems/sta/templates/items/smallcraftcontainer-sheet-legacy.hbs';
     return `systems/sta/templates/items/smallcraftcontainer-sheet.hbs`;
   }
 
@@ -36,7 +36,7 @@ export class STASmallCraftContainerSheet extends ItemSheet {
     data.dtypes = ['String', 'Number', 'Boolean'];
     let smallcrafts;
 
-    if (!foundry.utils.isNewerVersion(versionInfo, "0.8.-1")) {
+    if (!foundry.utils.isNewerVersion(versionInfo, '0.8.-1')) {
       smallcrafts = game.actors.filter((target) => 
         target.type === 'smallcraft' && target.owner);
     } else {

--- a/src/module/items/smallcraftcontainer-sheet.js
+++ b/src/module/items/smallcraftcontainer-sheet.js
@@ -21,7 +21,7 @@ export class STASmallCraftContainerSheet extends ItemSheet {
       ui.notifications.warn('You do not have permission to view this item!');
       return;
     }
-    if (!foundry.utils.isNewerVersion(versionInfo,"0.8.-1")) return "systems/sta/templates/items/smallcraftcontainer-sheet-legacy.hbs";
+    if (!foundry.utils.isNewerVersion(versionInfo, "0.8.-1")) return "systems/sta/templates/items/smallcraftcontainer-sheet-legacy.hbs";
     return `systems/sta/templates/items/smallcraftcontainer-sheet.hbs`;
   }
 
@@ -36,8 +36,7 @@ export class STASmallCraftContainerSheet extends ItemSheet {
     data.dtypes = ['String', 'Number', 'Boolean'];
     let smallcrafts;
 
-    if (!foundry.utils.isNewerVersion(versionInfo,"0.8.-1"))
-    {
+    if (!foundry.utils.isNewerVersion(versionInfo, "0.8.-1")) {
       smallcrafts = game.actors.filter((target) => 
         target.type === 'smallcraft' && target.owner);
     } else {

--- a/src/module/roll.js
+++ b/src/module/roll.js
@@ -93,7 +93,7 @@ export class STARoll {
       tokenId: speaker.token ? speaker.token.uuid : null,
       dicePool,
       checkTarget,
-      complicationMinimumValue: complicationMinimumValue + "+",
+      complicationMinimumValue: complicationMinimumValue + '+',
       diceHtml: diceString,
       complicationHtml: complicationText,
       successText,
@@ -479,7 +479,7 @@ export class STARoll {
   }
 
   async sendToChat(speaker, content, item, roll, flavor, sound) {
-    const rollMode = game.settings.get("core", "rollMode");
+    const rollMode = game.settings.get('core', 'rollMode');
     const messageProps = {
       user: game.user.id,
       speaker: ChatMessage.getSpeaker({actor: speaker}),

--- a/src/module/sta.js
+++ b/src/module/sta.js
@@ -70,7 +70,7 @@ import {
 /* -------------------------------------------- */
 
 Hooks.once('init', function() {
-  let versionInfo = game.world.coreVersion;
+  const versionInfo = game.world.coreVersion;
   // Splash Screen
   console.log(`Initializing Star Trek Adventures Tabletop Roleplaying Game System
                  .

--- a/src/module/sta.js
+++ b/src/module/sta.js
@@ -58,7 +58,7 @@ import {
   STAItem
 } from './items/item.js';
 import {
-  register_dsn_ufp_themes
+  registerDsnUfpThemes
 } from './dice/dice-so-nice.js';
 import {Collapsible} from './chat/Collapsible.js';
 import {
@@ -332,7 +332,7 @@ Hooks.once('init', function() {
   });
 
   Hooks.once('diceSoNiceReady', (dice3d) => {
-    register_dsn_ufp_themes(dice3d);
+    registerDsnUfpThemes(dice3d);
   });
 
   Hooks.on('rtcSettingsChanged', (settings, changed) => {


### PR DESCRIPTION
The hundreds of unresolved ESLint errors has made it difficult to use it as a static analysis tool; there are so many that it can be easy to miss a few new lines in reports showing up.  A workaround is to make sure ESLint is integrated into your IDE so it reports those issues directly as red squiggles as you type, which is great but not everyone is equipped to set up.

The vast majority of the existing ESLint reporting were about inconsistencies with "punctuation" (semicolons, braces, quote marks) and whitespace, making the ESLint feedback even more unnecessarily whiny.

I've done some passes on several batches of these issues to make them go away, as well as added a Github workflow that will include ESLint checking when someone pushes to Dev or does a Pull Request.