### PR TITLE
Develop

### DIFF
--- a/src/module/actors/sta-actors.mjs
+++ b/src/module/actors/sta-actors.mjs
@@ -443,10 +443,16 @@ export class STAActors extends api.HandlebarsApplicationMixin(sheets.ActorSheetV
       render: (event, dialog) => {
         const checkbox = dialog.element.querySelector('#starshipAssisting');
         const section = dialog.element.querySelector('.starshipAssisting');
-        if (!checkbox || !section) return;
+        const dicePoolSlider = dialog.element.querySelector('#dicePoolSlider');
+        if (!checkbox || !section || !dicePoolSlider) return;
         checkbox.addEventListener('change', () => {
           section.classList.toggle('hidden', !checkbox.checked);
-          dialog.setPosition({height: 'auto'});
+          if (checkbox.checked) {
+            dicePoolSlider.value = 2;
+          } else {
+            dicePoolSlider.value = 1;
+          }
+          dialog.setPosition({ height: 'auto' });
         });
       },
       buttons: [{

--- a/src/module/actors/sta-actors.mjs
+++ b/src/module/actors/sta-actors.mjs
@@ -337,6 +337,8 @@ export class STAActors extends api.HandlebarsApplicationMixin(sheets.ActorSheetV
   }
 
   _onSelectDiscipline(event) {
+    const useReputationInstead = this.element.querySelector('.rollrepnotdis input[type="checkbox"]');
+      useReputationInstead.checked = false;
     const clickedCheckbox = event.target;
     if (!clickedCheckbox.checked) {
       clickedCheckbox.checked = true;

--- a/src/module/actors/sta-actors.mjs
+++ b/src/module/actors/sta-actors.mjs
@@ -338,7 +338,7 @@ export class STAActors extends api.HandlebarsApplicationMixin(sheets.ActorSheetV
 
   _onSelectDiscipline(event) {
     const useReputationInstead = this.element.querySelector('.rollrepnotdis input[type="checkbox"]');
-      useReputationInstead.checked = false;
+    useReputationInstead.checked = false;
     const clickedCheckbox = event.target;
     if (!clickedCheckbox.checked) {
       clickedCheckbox.checked = true;
@@ -452,7 +452,7 @@ export class STAActors extends api.HandlebarsApplicationMixin(sheets.ActorSheetV
           } else {
             dicePoolSlider.value = 1;
           }
-          dialog.setPosition({ height: 'auto' });
+          dialog.setPosition({height: 'auto'});
         });
       },
       buttons: [{

--- a/src/module/apps/STARoller.mjs
+++ b/src/module/apps/STARoller.mjs
@@ -282,6 +282,10 @@ export class STARoller {
     <input type="checkbox" name="usingDetermination" id="usingDetermination">
   </div>
   <div class="row">
+    <div class="tracktitle">${game.i18n.localize(`sta.apps.complicationrange`)}</div>
+    <input class="numeric-entry" type="number" name="complicationRange" value="${calculatedComplicationRange}" id="complicationRange">
+  </div>
+  <div class="row">
     <div class="flex-1">
       <div class="tracktitle">${game.i18n.localize(`sta.apps.pool`)}</div>
     </div>
@@ -298,25 +302,6 @@ export class STARoller {
         <span class="label centered flex-1">5</span>
       </div>
       <input type="range" name="charDicePool" min="1" max="5" value="2" class="slider" id="char-dice-pool">
-    </div>
-  </div>
-  <div class="row">
-    <div class="flex-1">
-      <div class="tracktitle">${game.i18n.localize(`sta.roll.complicationrange`)}</div>
-    </div>
-    <div class="flex-column flex-1">
-      <div class="row">
-        <span class="label align-left flex-1">20</span>
-        <span class="centered flex-1"></span>
-        <span class="label centered flex-1">19+</span>
-        <span class="centered flex-1"></span>
-        <span class="label centered flex-1">18+</span>
-        <span class="centered flex-1"></span>
-        <span class="label centered flex-1">17+</span>
-        <span class="centered flex-1"></span>
-        <span class="label centered flex-1">16+</span>
-      </div>
-      <input type="range" name="complicationRange" min="1" max="5" value="${calculatedComplicationRange}" class="slider" id="complication-range">
     </div>
   </div>
   <div class="row">

--- a/src/module/apps/STARoller.mjs
+++ b/src/module/apps/STARoller.mjs
@@ -226,20 +226,20 @@ export class STARoller {
       <div class="tracktitle">${game.i18n.localize(`sta.actor.character.attribute.title`)}</div>
       <select id="attribute" name="attribute" class="form-select">
         ${attributes.map((attr) =>
-      `<option value="${attr}" ${attr === selectedAttr ? 'selected' : ''}>
+    `<option value="${attr}" ${attr === selectedAttr ? 'selected' : ''}>
             ${game.i18n.localize(`sta.actor.character.attribute.${attr}`)}
           </option>`
-    ).join('')}
+  ).join('')}
       </select>
     </div>
     <div class="row">
       <div class="tracktitle">${game.i18n.localize(`sta.actor.character.discipline.title`)}</div>
       <select id="discipline" name="discipline" class="form-select">
         ${disciplines.map((disc) =>
-      `<option value="${disc}" ${disc === selectedDisc ? 'selected' : ''}>
+    `<option value="${disc}" ${disc === selectedDisc ? 'selected' : ''}>
             ${game.i18n.localize(`sta.actor.character.discipline.${disc}`)}
           </option>`
-    ).join('')}
+  ).join('')}
       </select>
     </div>
   </div>

--- a/src/module/apps/STARoller.mjs
+++ b/src/module/apps/STARoller.mjs
@@ -207,28 +207,28 @@ export class STARoller {
     /* --------------------------------------------------------------------- */
     /* Templates                                                             */
     /* --------------------------------------------------------------------- */
-    const selectedAttr = attributes.find(attr => characterToken?.actor?.system?.attributes?.[attr]?.selected) ?? "";
-    const selectedDisc = disciplines.find(disc => characterToken?.actor?.system?.disciplines?.[disc]?.selected) ?? "";
+    const selectedAttr = attributes.find((attr) => characterToken?.actor?.system?.attributes?.[attr]?.selected) ?? '';
+    const selectedDisc = disciplines.find((disc) => characterToken?.actor?.system?.disciplines?.[disc]?.selected) ?? '';
     const characterSheet = `
   <div class="title">${character.name}</div>
   <div class="row">
     <div class="tracktitle">${game.i18n.localize(`sta.actor.character.attribute.title`)}</div>
     <select id="attribute" name="attribute" class="form-select">
-      ${attributes.map(attr =>
-        `<option value="${attr}" ${attr === selectedAttr ? "selected" : ""}>
+      ${attributes.map((attr) =>
+    `<option value="${attr}" ${attr === selectedAttr ? 'selected' : ''}>
           ${game.i18n.localize(`sta.actor.character.attribute.${attr}`)}
         </option>`
-      ).join('')}
+  ).join('')}
     </select>
   </div>
   <div class="row">
     <div class="tracktitle">${game.i18n.localize(`sta.actor.character.discipline.title`)}</div>
     <select id="discipline" name="discipline" class="form-select">
-      ${disciplines.map(disc =>
-        `<option value="${disc}" ${disc === selectedDisc ? "selected" : ""}>
+      ${disciplines.map((disc) =>
+    `<option value="${disc}" ${disc === selectedDisc ? 'selected' : ''}>
           ${game.i18n.localize(`sta.actor.character.discipline.${disc}`)}
         </option>`
-      ).join('')}
+  ).join('')}
     </select>
   </div>
   <div class="row">
@@ -237,29 +237,29 @@ export class STARoller {
   </div>
 `;
 
-    const selectedSys = systems.find(sys => starshipToken?.actor?.system?.systems?.[sys]?.selected) ?? "";
-    const selectedDept = departments.find(dept => starshipToken?.actor?.system?.departments?.[dept]?.selected) ?? "";
+    const selectedSys = systems.find((sys) => starshipToken?.actor?.system?.systems?.[sys]?.selected) ?? '';
+    const selectedDept = departments.find((dept) => starshipToken?.actor?.system?.departments?.[dept]?.selected) ?? '';
     const starshipSheet = `
   <div>
     <div class="title">${starship.name}</div>
     <div class="row">
       <div class="tracktitle">${game.i18n.localize(`sta.actor.starship.system.title`)}</div>
       <select id="system" name="system" class="form-select">
-        ${systems.map(system =>
-          `<option value="${system}" ${system === selectedSys ? "selected" : ""}>
+        ${systems.map((system) =>
+    `<option value="${system}" ${system === selectedSys ? 'selected' : ''}>
             ${game.i18n.localize(`sta.actor.starship.system.${system}`)}
           </option>`
-        ).join('')}
+  ).join('')}
       </select>
     </div>
     <div class="row">
       <div class="tracktitle">${game.i18n.localize(`sta.actor.starship.department.title`)}</div>
       <select id="department" name="department" class="form-select">
-        ${departments.map(dept =>
-          `<option value="${dept}" ${dept === selectedDept ? "selected" : ""}>
+        ${departments.map((dept) =>
+    `<option value="${dept}" ${dept === selectedDept ? 'selected' : ''}>
             ${game.i18n.localize(`sta.actor.starship.department.${dept}`)}
           </option>`
-        ).join('')}
+  ).join('')}
       </select>
     </div>
   </div>

--- a/src/module/apps/STARoller.mjs
+++ b/src/module/apps/STARoller.mjs
@@ -207,29 +207,41 @@ export class STARoller {
     /* --------------------------------------------------------------------- */
     /* Templates                                                             */
     /* --------------------------------------------------------------------- */
+    const sheetStart = `
+  <div>
+    <div class="row">
+      <div class="tracktitle">${game.i18n.localize(`sta.roll.task.name`)}</div>
+      <select id="rollList" name="rollList" class="form-select">
+        ${rollList.map((item) => `<option value="${item}">${game.i18n.localize(`sta.roll.${item}`)}</option>`).join('')}
+      </select>
+    </div>
+`;
+
     const selectedAttr = attributes.find((attr) => characterToken?.actor?.system?.attributes?.[attr]?.selected) ?? '';
     const selectedDisc = disciplines.find((disc) => characterToken?.actor?.system?.disciplines?.[disc]?.selected) ?? '';
     const characterSheet = `
   <div class="title">${character.name}</div>
-  <div class="row">
-    <div class="tracktitle">${game.i18n.localize(`sta.actor.character.attribute.title`)}</div>
-    <select id="attribute" name="attribute" class="form-select">
-      ${attributes.map((attr) =>
-    `<option value="${attr}" ${attr === selectedAttr ? 'selected' : ''}>
-          ${game.i18n.localize(`sta.actor.character.attribute.${attr}`)}
-        </option>`
-  ).join('')}
-    </select>
-  </div>
-  <div class="row">
-    <div class="tracktitle">${game.i18n.localize(`sta.actor.character.discipline.title`)}</div>
-    <select id="discipline" name="discipline" class="form-select">
-      ${disciplines.map((disc) =>
-    `<option value="${disc}" ${disc === selectedDisc ? 'selected' : ''}>
-          ${game.i18n.localize(`sta.actor.character.discipline.${disc}`)}
-        </option>`
-  ).join('')}
-    </select>
+  <div class="characterRollList">
+    <div class="row">
+      <div class="tracktitle">${game.i18n.localize(`sta.actor.character.attribute.title`)}</div>
+      <select id="attribute" name="attribute" class="form-select">
+        ${attributes.map((attr) =>
+      `<option value="${attr}" ${attr === selectedAttr ? 'selected' : ''}>
+            ${game.i18n.localize(`sta.actor.character.attribute.${attr}`)}
+          </option>`
+    ).join('')}
+      </select>
+    </div>
+    <div class="row">
+      <div class="tracktitle">${game.i18n.localize(`sta.actor.character.discipline.title`)}</div>
+      <select id="discipline" name="discipline" class="form-select">
+        ${disciplines.map((disc) =>
+      `<option value="${disc}" ${disc === selectedDisc ? 'selected' : ''}>
+            ${game.i18n.localize(`sta.actor.character.discipline.${disc}`)}
+          </option>`
+    ).join('')}
+      </select>
+    </div>
   </div>
   <div class="row">
     <div class="tracktitle">${game.i18n.localize(`sta.apps.focus`)}</div>
@@ -240,8 +252,8 @@ export class STARoller {
     const selectedSys = systems.find((sys) => starshipToken?.actor?.system?.systems?.[sys]?.selected) ?? '';
     const selectedDept = departments.find((dept) => starshipToken?.actor?.system?.departments?.[dept]?.selected) ?? '';
     const starshipSheet = `
-  <div>
-    <div class="title">${starship.name}</div>
+  <div class="title">${starship.name}</div>
+  <div class="starshipRollList">
     <div class="row">
       <div class="tracktitle">${game.i18n.localize(`sta.actor.starship.system.title`)}</div>
       <select id="system" name="system" class="form-select">
@@ -257,7 +269,7 @@ export class STARoller {
       <select id="department" name="department" class="form-select">
         ${departments.map((dept) =>
     `<option value="${dept}" ${dept === selectedDept ? 'selected' : ''}>
-            ${game.i18n.localize(`sta.actor.starship.department.${dept}`)}
+       ${game.i18n.localize(`sta.actor.starship.department.${dept}`)}
           </option>`
   ).join('')}
       </select>
@@ -281,7 +293,6 @@ export class STARoller {
 `;
 
     const starshipNPCSheet = `
-  <div>
     <div class="title">${game.i18n.localize(`sta.roll.npcship`)}</div>
     <div class="row">
       <div class="tracktitle">${game.i18n.localize(`sta.actor.starship.system.title`)}</div>
@@ -325,12 +336,6 @@ export class STARoller {
       <input type="range" name="charDicePool" min="1" max="5" value="2" class="slider" id="char-dice-pool">
     </div>
   </div>
-  <div class="row">
-    <div class="tracktitle">${game.i18n.localize(`sta.roll.task.name`)}</div>
-    <select id="rollList" name="rollList" class="form-select">
-      ${rollList.map((item) => `<option value="${item}">${game.i18n.localize(`sta.roll.${item}`)}</option>`).join('')}
-    </select>
-  </div>
 </div>
 `;
 
@@ -339,13 +344,13 @@ export class STARoller {
     /* --------------------------------------------------------------------- */
     let template = '';
     if (!characterToken && !starshipToken) {
-      template = starshipNPCSheet + characterNPCSheet + commonForm;
+      template = sheetStart + starshipNPCSheet + characterNPCSheet + commonForm;
     } else if (!characterToken && starshipToken) {
-      template = starshipSheet + characterNPCSheet + commonForm;
+      template = sheetStart + starshipSheet + characterNPCSheet + commonForm;
     } else if (characterToken && !starshipToken) {
-      template = starshipNPCSheet + characterSheet + commonForm;
+      template = sheetStart + starshipNPCSheet + characterSheet + commonForm;
     } else {
-      template = starshipSheet + characterSheet + commonForm;
+      template = sheetStart + starshipSheet + characterSheet + commonForm;
     }
 
     /* --------------------------------------------------------------------- */
@@ -358,6 +363,23 @@ export class STARoller {
       position: {height: 'auto', width: 450},
       content: template,
       classes: ['dialogue'],
+      render: (event, dialog) => {
+        const checkbox = dialog.element.querySelector('#rollList');
+        const characterSection = dialog.element.querySelector('.characterRollList');
+        const starshipSection = dialog.element.querySelector('.starshipRollList');
+        checkbox.addEventListener('change', () => {
+          const value = checkbox.value;
+          const isBoth = value === 'justrollboth';
+          const isCrew = value === 'justrollcrew';
+          if (characterSection) {
+            characterSection.classList.toggle('hidden', !(isBoth || isCrew));
+          }
+          if (starshipSection) {
+            starshipSection.classList.toggle('hidden', !isBoth);
+          }
+          dialog.setPosition({height: 'auto'});
+        });
+      },
       buttons: [{
         action: 'roll',
         default: true,

--- a/src/module/apps/STARoller.mjs
+++ b/src/module/apps/STARoller.mjs
@@ -207,18 +207,28 @@ export class STARoller {
     /* --------------------------------------------------------------------- */
     /* Templates                                                             */
     /* --------------------------------------------------------------------- */
+    const selectedAttr = attributes.find(attr => characterToken?.actor?.system?.attributes?.[attr]?.selected) ?? "";
+    const selectedDisc = disciplines.find(disc => characterToken?.actor?.system?.disciplines?.[disc]?.selected) ?? "";
     const characterSheet = `
   <div class="title">${character.name}</div>
   <div class="row">
     <div class="tracktitle">${game.i18n.localize(`sta.actor.character.attribute.title`)}</div>
     <select id="attribute" name="attribute" class="form-select">
-      ${attributes.map((attr) => `<option value="${attr}">${game.i18n.localize(`sta.actor.character.attribute.${attr}`)}</option>`).join('')}
+      ${attributes.map(attr =>
+        `<option value="${attr}" ${attr === selectedAttr ? "selected" : ""}>
+          ${game.i18n.localize(`sta.actor.character.attribute.${attr}`)}
+        </option>`
+      ).join('')}
     </select>
   </div>
   <div class="row">
     <div class="tracktitle">${game.i18n.localize(`sta.actor.character.discipline.title`)}</div>
     <select id="discipline" name="discipline" class="form-select">
-      ${disciplines.map((disc) => `<option value="${disc}">${game.i18n.localize(`sta.actor.character.discipline.${disc}`)}</option>`).join('')}
+      ${disciplines.map(disc =>
+        `<option value="${disc}" ${disc === selectedDisc ? "selected" : ""}>
+          ${game.i18n.localize(`sta.actor.character.discipline.${disc}`)}
+        </option>`
+      ).join('')}
     </select>
   </div>
   <div class="row">
@@ -227,21 +237,32 @@ export class STARoller {
   </div>
 `;
 
+    const selectedSys = systems.find(sys => starshipToken?.actor?.system?.systems?.[sys]?.selected) ?? "";
+    const selectedDept = departments.find(dept => starshipToken?.actor?.system?.departments?.[dept]?.selected) ?? "";
     const starshipSheet = `
   <div>
     <div class="title">${starship.name}</div>
     <div class="row">
       <div class="tracktitle">${game.i18n.localize(`sta.actor.starship.system.title`)}</div>
       <select id="system" name="system" class="form-select">
-        ${systems.map((system) => `<option value="${system}">${game.i18n.localize(`sta.actor.starship.system.${system}`)}</option>`).join('')}
+        ${systems.map(system =>
+          `<option value="${system}" ${system === selectedSys ? "selected" : ""}>
+            ${game.i18n.localize(`sta.actor.starship.system.${system}`)}
+          </option>`
+        ).join('')}
       </select>
     </div>
     <div class="row">
       <div class="tracktitle">${game.i18n.localize(`sta.actor.starship.department.title`)}</div>
       <select id="department" name="department" class="form-select">
-        ${departments.map((dept) => `<option value="${dept}">${game.i18n.localize(`sta.actor.starship.department.${dept}`)}</option>`).join('')}
+        ${departments.map(dept =>
+          `<option value="${dept}" ${dept === selectedDept ? "selected" : ""}>
+            ${game.i18n.localize(`sta.actor.starship.department.${dept}`)}
+          </option>`
+        ).join('')}
       </select>
     </div>
+  </div>
 `;
 
     const characterNPCSheet = `

--- a/src/templates/apps/tracker.hbs
+++ b/src/templates/apps/tracker.hbs
@@ -6,7 +6,7 @@
 
   <div class="row">
     <div class="icon-container">
-      <div id="sta-roll-npc-button" class="button roll-npc" title="{{localize 'sta.roll.npccrew'}}" data-action="onNPCRoll">
+      <div id="sta-roll-npc-button" class="button roll-npc" title="{{localize 'sta.apps.staroller'}}" data-action="onNPCRoll">
         <i class="combadge"></i>
       </div>
       <div id="sta-roll-task-button" class="button roll-task" title="{{localize 'sta.actor.attdis.task'}}" data-action="onTaskRoll">


### PR DESCRIPTION
- Roll reputation box unselects when a new discipline is selected
- When selecting to make a ship and NPC ship in task rolls, dice pool automatically updates from 1 to 2
- STA Roller now chooses the Attributes selected in the actor sheet as a starting point
- Reorganisation of STA Roller, it now hides the unused combo boxes when a pre-defined roll is selected